### PR TITLE
Chore/29 local docker init setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+POSTGRES_DB=baedalsodae
+POSTGRES_DB_URL=jdbc:postgresql://localhost:5432/baedalsodae
+POSTGRES_USER=
+POSTGRES_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -248,8 +248,9 @@ docker compose down -v
 #### 백엔드
 
 ```bash
-# 환경 변수 설정 후 실행
-export POSTGRES_URL=jdbc:postgresql://localhost:5432/baedalsodae
+# 환경 변수 설정 후 실행(인텔레제이 환경 변수 사용도 가능)
+export POSTGRES_DB=baedalsodae
+export POSTGRES_DB_URL=jdbc:postgresql://localhost:5432/baedalsodae
 export POSTGRES_USER=baedal_user
 export POSTGRES_PASSWORD=your_password
 export REDIS_HOST=localhost
@@ -265,6 +266,25 @@ cd frontend
 npm install
 npm run dev
 ```
+
+---
+
+## 로컬 환경 세팅
+
+> 백엔드 단독 로컬 실행 시 사용하는 간단한 세팅 가이드입니다.
+
+1. `.env.example`을 복사해서 `.env` 파일 생성 후 값 입력
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Docker로 PostgreSQL 실행
+   ```bash
+   docker-compose up -d
+   ```
+
+3. 애플리케이션 실행
+  - 인텔레제이 환경 변수 설정 후 실행
 
 ---
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS baedalsodae;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  postgres:
+    image: postgres:17
+    container_name: baedalsodae-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: baedalsodae
+    env_file:
+      - .env
+    volumes:
+      - ./db:/docker-entrypoint-initdb.d
+    restart: unless-stopped

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: false
+    show-sql: true
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc.time_zone: Asia/Seoul
+  sql:
+    init:
+      mode: never


### PR DESCRIPTION
### 📌 관련 이슈
- close #29
- 
### 💡 작업 내용
- chore: application-test.yml 추가 jaebin1234 <jaebin2586@gmail.com> 2d866bb57f8aefb3ac6a578c236160aa210a841a 2026-02-28 오후 5:35:44
- chore: docker-compose 생성 및 초기세팅(postgres17) jaebin1234 <jaebin2586@gmail.com> e2d15848d05c6b7a83b39347aa8e35f487628d72 2026-02-28 오후 6:28:54
- feat: .env 예시 파일 생성(실제 .env파일은 gitignore) jaebin1234 <jaebin2586@gmail.com> ed7e5589460ce3745881a2de54e54d12a62e1040 2026-02-28 오후 6:29:24
- feat: db/init.sql 생성(스키마 생성) jaebin1234 <jaebin2586@gmail.com> 2d55292595d03e5094cf2b5f330005199052f20c 2026-02-28 오후 6:30:05
- docs: 로컬 환경 세팅 관련 가이드 README.md에 추가 jaebin1234 <jaebin2586@gmail.com> 99fc90e8176239631995ecbaaf848bb26cc3bca0 2026-02-28 오후 6:30:47

### 🔍 변경 이유
- 로컬 도커 환경을 세팅하고 postgres17을 추가 하여, 로컬에서 애플리케이션, db를 사용

### 📝 리뷰 포인트 (선택)


### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)