### PR TITLE
Feat/27 location entity

### DIFF
--- a/src/main/java/com/project/baedalsodae/location/entity/EndArea.java
+++ b/src/main/java/com/project/baedalsodae/location/entity/EndArea.java
@@ -1,0 +1,37 @@
+package com.project.baedalsodae.location.entity;
+
+import com.project.baedalsodae.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "p_end_areas")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EndArea extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "adm_code", nullable = false, length = 50, unique = true)
+    private String admCode;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "location")
+    private String location;
+
+    @Column(name = "version", length = 20)
+    private String version;
+}

--- a/src/main/java/com/project/baedalsodae/location/entity/EndArea.java
+++ b/src/main/java/com/project/baedalsodae/location/entity/EndArea.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "p_end_areas")
+@Table(name = "p_end_area")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EndArea extends BaseTimeEntity {
 
@@ -32,6 +33,6 @@ public class EndArea extends BaseTimeEntity {
     @Column(name = "location")
     private String location;
 
-    @Column(name = "version", length = 20)
-    private String version;
+    @Version
+    private Long version;
 }

--- a/src/main/java/com/project/baedalsodae/location/entity/SidoArea.java
+++ b/src/main/java/com/project/baedalsodae/location/entity/SidoArea.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "p_sido_areas")
+@Table(name = "p_sido_area")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SidoArea extends BaseTimeEntity {
 
@@ -29,6 +30,6 @@ public class SidoArea extends BaseTimeEntity {
     @Column(name = "name", nullable = false, length = 100)
     private String name;
 
-    @Column(name = "version", length = 20)
-    private String version;
+    @Version
+    private Long version;
 }

--- a/src/main/java/com/project/baedalsodae/location/entity/SidoArea.java
+++ b/src/main/java/com/project/baedalsodae/location/entity/SidoArea.java
@@ -1,0 +1,34 @@
+package com.project.baedalsodae.location.entity;
+
+import com.project.baedalsodae.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "p_sido_areas")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SidoArea extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "adm_code", nullable = false, length = 50, unique = true)
+    private String admCode;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "version", length = 20)
+    private String version;
+}

--- a/src/main/java/com/project/baedalsodae/location/entity/SiggArea.java
+++ b/src/main/java/com/project/baedalsodae/location/entity/SiggArea.java
@@ -1,0 +1,31 @@
+package com.project.baedalsodae.location.entity;
+
+import com.project.baedalsodae.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "p_sigg_area")
+public class SiggArea extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "adm_code", nullable = false, length = 50, unique = true)
+    private String admCode;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "version", length = 20)
+    private String version;
+}

--- a/src/main/java/com/project/baedalsodae/location/entity/SiggArea.java
+++ b/src/main/java/com/project/baedalsodae/location/entity/SiggArea.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -29,6 +30,6 @@ public class SiggArea extends BaseTimeEntity {
     @Column(name = "name", nullable = false, length = 100)
     private String name;
 
-    @Column(name = "version", length = 20)
-    private String version;
+    @Version
+    private Long version;
 }

--- a/src/main/java/com/project/baedalsodae/location/entity/SiggArea.java
+++ b/src/main/java/com/project/baedalsodae/location/entity/SiggArea.java
@@ -8,11 +8,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
 @Table(name = "p_sigg_area")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SiggArea extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
### 📌 관련 이슈
- close #27

### 💡 작업 내용
- 지역 도메인 관련 엔티티 추가
  - 엔티티의 이름으로는 테이블 이름에서 `p_` 부분만 뺀 이름을 사용(ex: 테이블이 `p_sido_area` -> 엔티티는 `SidoArea`)
  - 지역 도메인에 관한 `location` 패키지 추가
- 추가한 엔티티 중 시군구(SiggArea), 읍면동(EndArea)의 외래키 삭제
  - 시군구 -> sido_id 삭제
  - 읍면동 -> sigg_id 삭제

### 🔍 변경 이유
- 회원 주소 및 가게 엔티티에서 참조하는 sido_id, sigungu_id, dong_id에 관한 원본 데이터를 제공하기 위해 필요
(2개 이상 도메인에서 참조하기 때문에 milestone은 '공통 기능 구현'으로 선택)

### 📝 리뷰 포인트 (선택)

- 추가한 엔티티 중 시군구(SiggArea), 읍면동(EndArea)에서 다음의 외래키 삭제
  - 시군구 -> sido_id 삭제
  - 읍면동 -> sigg_id 삭제
  - 관련 내용은 개발 기록 보드에도 작성

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)