### PR TITLE
Feat/44 global exception add

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/project/baedalsodae/global/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/baedalsodae/global/common/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.project.baedalsodae.global.common;
 
 import jakarta.transaction.SystemException;
 import lombok.extern.slf4j.Slf4j;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -61,6 +62,20 @@ public class GlobalExceptionHandler {
 
         String message = String.format("'%s' 파라미터의 값이 올바르지 않습니다: %s",
                 exception.getName(), exception.getValue());
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_REQUEST.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_REQUEST, message));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<String>> handleConstraintViolation(
+            ConstraintViolationException exception) {
+        log.warn("Constraint Violation: ", exception);
+
+        String message = exception.getConstraintViolations().stream()
+                .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+                .collect(Collectors.joining(", "));
 
         return ResponseEntity
                 .status(ErrorCode.INVALID_REQUEST.getStatus())


### PR DESCRIPTION
### 📌 관련 이슈
- close #44
- 
### 💡 작업 내용
- feat: spring-boot-starter-validation 라이브러리 추가 jaebin1234 <jaebin2586@gmail.com> 641f867cbef1e7b936c2a571383c5e10f6ddedf9 2026-03-02 오전 1:14:48
- feat: ConstraintViolationException 예외 전역 예외 핸들러에 추가 jaebin1234 <jaebin2586@gmail.com> a382ecd079e6211a698557ab4c29d9d69b9e2f6d 2026-03-02 오전 1:15:20

### 🔍 변경 이유
- validation 라이브러리를 추가하고, 전역 예외 핸들러에 Pathvariable, RequestParam 관련 예외 추가(ConstraintViolationException )

### 📝 리뷰 포인트 (선택)


### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)