### PR TITLE
Feat/36 create tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -40,4 +40,11 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+        showExceptions true
+        showCauses true
+        showStackTraces true
+        exceptionFormat "full"
+    }
 }

--- a/src/main/java/com/project/baedalsodae/tag/entity/Tag.java
+++ b/src/main/java/com/project/baedalsodae/tag/entity/Tag.java
@@ -1,7 +1,7 @@
 package com.project.baedalsodae.tag.entity;
 
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -26,7 +26,7 @@ public class Tag {
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   public static Tag create(String name) {
     Tag tag = new Tag();

--- a/src/main/java/com/project/baedalsodae/tag/entity/Tag.java
+++ b/src/main/java/com/project/baedalsodae/tag/entity/Tag.java
@@ -1,14 +1,13 @@
 package com.project.baedalsodae.tag.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Entity
 @Table(name = "p_tag")
@@ -17,16 +16,21 @@ import java.util.UUID;
 @EntityListeners(AuditingEntityListener.class)
 public class Tag {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "id", nullable = false)
-    private UUID id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "id", nullable = false)
+  private UUID id;
 
-    @Column(name = "name", nullable = false, unique = true)
-    private String name;
+  @Column(name = "name", nullable = false, unique = true)
+  private String name;
 
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
 
+  public static Tag create(String name) {
+    Tag tag = new Tag();
+    tag.name = name;
+    return tag;
+  }
 }

--- a/src/main/java/com/project/baedalsodae/tag/entity/TagMapping.java
+++ b/src/main/java/com/project/baedalsodae/tag/entity/TagMapping.java
@@ -36,4 +36,12 @@ public class TagMapping {
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
   private LocalDateTime createdAt;
+
+  public static TagMapping create(Tag tag, MenuItem menuItem, int orderNo) {
+    TagMapping tagMapping = new TagMapping();
+    tagMapping.tag = tag;
+    tagMapping.menuItem = menuItem;
+    tagMapping.orderNo = orderNo;
+    return tagMapping;
+  }
 }

--- a/src/main/java/com/project/baedalsodae/tag/entity/TagMapping.java
+++ b/src/main/java/com/project/baedalsodae/tag/entity/TagMapping.java
@@ -2,7 +2,7 @@ package com.project.baedalsodae.tag.entity;
 
 import com.project.baedalsodae.menu.entity.MenuItem;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -35,7 +35,7 @@ public class TagMapping {
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   public static TagMapping create(Tag tag, MenuItem menuItem, int orderNo) {
     TagMapping tagMapping = new TagMapping();

--- a/src/main/java/com/project/baedalsodae/tag/repository/TagBulkRepository.java
+++ b/src/main/java/com/project/baedalsodae/tag/repository/TagBulkRepository.java
@@ -1,0 +1,28 @@
+package com.project.baedalsodae.tag.repository;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class TagBulkRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  @Transactional
+  public void bulkInsertIgnore(List<String> tagNames) {
+    if (tagNames == null || tagNames.isEmpty()) return;
+
+    String sql =
+        """
+            INSERT INTO tag (name)
+            VALUES (?)
+            ON CONFLICT (name) DO NOTHING
+        """;
+
+    jdbcTemplate.batchUpdate(sql, tagNames, tagNames.size(), (ps, name) -> ps.setString(1, name));
+  }
+}

--- a/src/main/java/com/project/baedalsodae/tag/repository/TagMappingRepository.java
+++ b/src/main/java/com/project/baedalsodae/tag/repository/TagMappingRepository.java
@@ -3,5 +3,12 @@ package com.project.baedalsodae.tag.repository;
 import com.project.baedalsodae.tag.entity.TagMapping;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-public interface TagMappingRepository extends JpaRepository<TagMapping, UUID> {}
+public interface TagMappingRepository extends JpaRepository<TagMapping, UUID> {
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("DELETE FROM TagMapping tm WHERE tm.menuItem.id = :menuItemId")
+  void deleteByMenuItemId(UUID menuItemId);
+}

--- a/src/main/java/com/project/baedalsodae/tag/repository/TagMappingRepository.java
+++ b/src/main/java/com/project/baedalsodae/tag/repository/TagMappingRepository.java
@@ -1,0 +1,7 @@
+package com.project.baedalsodae.tag.repository;
+
+import com.project.baedalsodae.tag.entity.TagMapping;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagMappingRepository extends JpaRepository<TagMapping, UUID> {}

--- a/src/main/java/com/project/baedalsodae/tag/repository/TagRepository.java
+++ b/src/main/java/com/project/baedalsodae/tag/repository/TagRepository.java
@@ -1,0 +1,9 @@
+package com.project.baedalsodae.tag.repository;
+
+import com.project.baedalsodae.tag.entity.Tag;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, UUID> {
+}

--- a/src/main/java/com/project/baedalsodae/tag/repository/TagRepository.java
+++ b/src/main/java/com/project/baedalsodae/tag/repository/TagRepository.java
@@ -1,9 +1,15 @@
 package com.project.baedalsodae.tag.repository;
 
 import com.project.baedalsodae.tag.entity.Tag;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, UUID> {
+
+  Optional<Tag> findByName(String name);
+
+  List<Tag> findAllByNameIn(Collection<String> names);
 }

--- a/src/main/java/com/project/baedalsodae/tag/service/Impl/TagMappingServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/Impl/TagMappingServiceImpl.java
@@ -6,10 +6,7 @@ import com.project.baedalsodae.tag.entity.TagMapping;
 import com.project.baedalsodae.tag.repository.TagMappingRepository;
 import com.project.baedalsodae.tag.service.TagMappingService;
 import com.project.baedalsodae.tag.service.TagService;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -57,5 +54,11 @@ public class TagMappingServiceImpl implements TagMappingService {
     }
 
     tagMappingRepository.saveAll(tagMappings);
+  }
+
+  @Transactional
+  @Override
+  public void deleteAllTagMappingByMenuItemId(UUID menuItemId) {
+    tagMappingRepository.deleteByMenuItemId(menuItemId);
   }
 }

--- a/src/main/java/com/project/baedalsodae/tag/service/Impl/TagMappingServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/Impl/TagMappingServiceImpl.java
@@ -7,8 +7,8 @@ import com.project.baedalsodae.tag.repository.TagMappingRepository;
 import com.project.baedalsodae.tag.service.TagMappingService;
 import com.project.baedalsodae.tag.service.TagService;
 import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,32 +23,19 @@ public class TagMappingServiceImpl implements TagMappingService {
   @Transactional
   public void createTagMappings(MenuItem menuItem, List<String> tagNames) {
 
-    Map<String, Tag> resolvedTagMap = new HashMap<>();
+    List<String> distinctNames = tagNames.stream().distinct().toList();
 
-    List<Tag> tagList = tagService.findAllByNames(tagNames);
-    for (Tag tag : tagList) {
-      resolvedTagMap.put(tag.getName(), tag);
-    }
+    tagService.createNewTagsIfNotExists(distinctNames);
 
-    List<String> tagNotFoundNames =
-        tagNames.stream().filter(name -> !resolvedTagMap.containsKey(name)).toList();
-
-    if (!tagNotFoundNames.isEmpty()) {
-      try {
-        Map<String, Tag> newTagMap = tagService.createNewTags(tagNotFoundNames);
-        resolvedTagMap.putAll(newTagMap);
-      } catch (DataIntegrityViolationException e) {
-        for (String name : tagNotFoundNames) {
-          resolvedTagMap.put(name, tagService.findOrCreateTag(name));
-        }
-      }
-    }
+    Map<String, Tag> tagMap =
+        tagService.findAllByNames(distinctNames).stream()
+            .collect(Collectors.toMap(Tag::getName, t -> t));
 
     List<TagMapping> tagMappings = new ArrayList<>();
 
     for (int i = 0; i < tagNames.size(); i++) {
       String tagName = tagNames.get(i);
-      Tag tag = resolvedTagMap.get(tagName);
+      Tag tag = tagMap.get(tagName);
       TagMapping mapping = TagMapping.create(tag, menuItem, i);
       tagMappings.add(mapping);
     }

--- a/src/main/java/com/project/baedalsodae/tag/service/Impl/TagMappingServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/Impl/TagMappingServiceImpl.java
@@ -1,0 +1,61 @@
+package com.project.baedalsodae.tag.service.Impl;
+
+import com.project.baedalsodae.menu.entity.MenuItem;
+import com.project.baedalsodae.tag.entity.Tag;
+import com.project.baedalsodae.tag.entity.TagMapping;
+import com.project.baedalsodae.tag.repository.TagMappingRepository;
+import com.project.baedalsodae.tag.service.TagMappingService;
+import com.project.baedalsodae.tag.service.TagService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TagMappingServiceImpl implements TagMappingService {
+
+  private final TagService tagService;
+  private final TagMappingRepository tagMappingRepository;
+
+  @Override
+  @Transactional
+  public void createTagMappings(MenuItem menuItem, List<String> tagNames) {
+
+    Map<String, Tag> resolvedTagMap = new HashMap<>();
+
+    List<Tag> tagList = tagService.findAllByNames(tagNames);
+    for (Tag tag : tagList) {
+      resolvedTagMap.put(tag.getName(), tag);
+    }
+
+    List<String> tagNotFoundNames =
+        tagNames.stream().filter(name -> !resolvedTagMap.containsKey(name)).toList();
+
+    if (!tagNotFoundNames.isEmpty()) {
+      try {
+        Map<String, Tag> newTagMap = tagService.createNewTags(tagNotFoundNames);
+        resolvedTagMap.putAll(newTagMap);
+      } catch (DataIntegrityViolationException e) {
+        for (String name : tagNotFoundNames) {
+          resolvedTagMap.put(name, tagService.findOrCreateTag(name));
+        }
+      }
+    }
+
+    List<TagMapping> tagMappings = new ArrayList<>();
+
+    for (int i = 0; i < tagNames.size(); i++) {
+      String tagName = tagNames.get(i);
+      Tag tag = resolvedTagMap.get(tagName);
+      TagMapping mapping = TagMapping.create(tag, menuItem, i);
+      tagMappings.add(mapping);
+    }
+
+    tagMappingRepository.saveAll(tagMappings);
+  }
+}

--- a/src/main/java/com/project/baedalsodae/tag/service/Impl/TagServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/Impl/TagServiceImpl.java
@@ -1,14 +1,12 @@
 package com.project.baedalsodae.tag.service.Impl;
 
 import com.project.baedalsodae.tag.entity.Tag;
+import com.project.baedalsodae.tag.repository.TagBulkRepository;
 import com.project.baedalsodae.tag.repository.TagRepository;
 import com.project.baedalsodae.tag.service.TagService;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -16,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TagServiceImpl implements TagService {
 
   private final TagRepository tagRepository;
+  private final TagBulkRepository tagBulkRepository;
 
   @Override
   @Transactional(readOnly = true)
@@ -24,19 +23,8 @@ public class TagServiceImpl implements TagService {
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public Map<String, Tag> createNewTags(List<String> names) {
-    List<Tag> tags = names.stream().map(Tag::create).toList();
-    tagRepository.saveAllAndFlush(tags);
-    return tags.stream().collect(Collectors.toMap(Tag::getName, t -> t));
+  public void createNewTagsIfNotExists(List<String> tagNames) {
+    List<String> distinctNames = tagNames.stream().distinct().toList();
+    tagBulkRepository.bulkInsertIgnore(distinctNames);
   }
-
-  @Override
-  public Tag findOrCreateTag(String name) {
-    return tagRepository.findByName(name).orElseGet(() -> {
-      Tag newTag = Tag.create(name);
-      return tagRepository.saveAndFlush(newTag);
-    });
-  }
-
 }

--- a/src/main/java/com/project/baedalsodae/tag/service/Impl/TagServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/Impl/TagServiceImpl.java
@@ -1,0 +1,42 @@
+package com.project.baedalsodae.tag.service.Impl;
+
+import com.project.baedalsodae.tag.entity.Tag;
+import com.project.baedalsodae.tag.repository.TagRepository;
+import com.project.baedalsodae.tag.service.TagService;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TagServiceImpl implements TagService {
+
+  private final TagRepository tagRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<Tag> findAllByNames(List<String> names) {
+    return tagRepository.findAllByNameIn(names);
+  }
+
+  @Override
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public Map<String, Tag> createNewTags(List<String> names) {
+    List<Tag> tags = names.stream().map(Tag::create).toList();
+    tagRepository.saveAllAndFlush(tags);
+    return tags.stream().collect(Collectors.toMap(Tag::getName, t -> t));
+  }
+
+  @Override
+  public Tag findOrCreateTag(String name) {
+    return tagRepository.findByName(name).orElseGet(() -> {
+      Tag newTag = Tag.create(name);
+      return tagRepository.saveAndFlush(newTag);
+    });
+  }
+
+}

--- a/src/main/java/com/project/baedalsodae/tag/service/TagMappingService.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/TagMappingService.java
@@ -1,9 +1,13 @@
 package com.project.baedalsodae.tag.service;
 
 import com.project.baedalsodae.menu.entity.MenuItem;
+
 import java.util.List;
+import java.util.UUID;
 
 public interface TagMappingService {
 
   void createTagMappings(MenuItem menuItem, List<String> tagNames);
+
+  void deleteAllTagMappingByMenuItemId(UUID menuItemId);
 }

--- a/src/main/java/com/project/baedalsodae/tag/service/TagMappingService.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/TagMappingService.java
@@ -1,7 +1,6 @@
 package com.project.baedalsodae.tag.service;
 
 import com.project.baedalsodae.menu.entity.MenuItem;
-
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/project/baedalsodae/tag/service/TagMappingService.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/TagMappingService.java
@@ -1,0 +1,9 @@
+package com.project.baedalsodae.tag.service;
+
+import com.project.baedalsodae.menu.entity.MenuItem;
+import java.util.List;
+
+public interface TagMappingService {
+
+  void createTagMappings(MenuItem menuItem, List<String> tagNames);
+}

--- a/src/main/java/com/project/baedalsodae/tag/service/TagService.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/TagService.java
@@ -1,0 +1,14 @@
+package com.project.baedalsodae.tag.service;
+
+import com.project.baedalsodae.tag.entity.Tag;
+import java.util.List;
+import java.util.Map;
+
+public interface TagService {
+
+  List<Tag> findAllByNames(List<String> names);
+
+  Map<String, Tag> createNewTags(List<String> names);
+
+  Tag findOrCreateTag(String name);
+}

--- a/src/main/java/com/project/baedalsodae/tag/service/TagService.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/TagService.java
@@ -8,7 +8,5 @@ public interface TagService {
 
   List<Tag> findAllByNames(List<String> names);
 
-  Map<String, Tag> createNewTags(List<String> names);
-
-  Tag findOrCreateTag(String name);
+  void createNewTagsIfNotExists(List<String> distinctNames);
 }

--- a/src/test/java/com/project/baedalsodae/tag/service/TagMappingServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/tag/service/TagMappingServiceImplTest.java
@@ -1,0 +1,109 @@
+package com.project.baedalsodae.tag.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import com.project.baedalsodae.menu.entity.MenuItem;
+import com.project.baedalsodae.tag.entity.Tag;
+import com.project.baedalsodae.tag.repository.TagMappingRepository;
+import com.project.baedalsodae.tag.service.Impl.TagMappingServiceImpl;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class TagMappingServiceImplTest {
+
+  @Mock
+  private TagService tagService;
+
+  @Mock
+  private TagMappingRepository tagMappingRepository;
+
+  @InjectMocks
+  private TagMappingServiceImpl tagMappingService;
+
+  @Test
+  @DisplayName("모든 태그가 이미 존재하면 배치 생성 없이 TagMapping을 저장한다")
+  void createTagMappings_whenAllTagsExist_savesWithoutBatchCreation() {
+    // given
+    MenuItem menuItem = mock(MenuItem.class);
+    Tag tag1 = mock(Tag.class);
+    Tag tag2 = mock(Tag.class);
+    given(tag1.getName()).willReturn("치킨");
+    given(tag2.getName()).willReturn("피자");
+    given(tagService.findAllByNames(anyList())).willReturn(List.of(tag1, tag2));
+
+    // when
+    tagMappingService.createTagMappings(menuItem, List.of("치킨", "피자"));
+
+    // then
+    then(tagService).should(never()).createNewTags(anyList());
+    then(tagMappingRepository).should().saveAll(anyList());
+  }
+
+  @Test
+  @DisplayName("신규 태그가 있으면 배치 생성 후 TagMapping을 저장한다")
+  void createTagMappings_addsNewTagsAndSavesMappings() {
+    // given
+    MenuItem menuItem = mock(MenuItem.class);
+    Tag existingTag = mock(Tag.class);
+    Tag newTag = mock(Tag.class);
+    given(existingTag.getName()).willReturn("치킨");
+    given(tagService.findAllByNames(anyList())).willReturn(List.of(existingTag));
+    given(tagService.createNewTags(List.of("피자"))).willReturn(Map.of("피자", newTag));
+
+    // when
+    tagMappingService.createTagMappings(menuItem, List.of("치킨", "피자"));
+
+    // then
+    then(tagService).should().createNewTags(List.of("피자"));
+    then(tagMappingRepository).should().saveAll(anyList());
+  }
+
+  @Test
+  @DisplayName("배치 생성 중 동시 충돌 발생 시 개별 findOrCreateTag로 fallback 처리한다")
+  void createTagMappings_batchCreationConflict_fallbackToFindOrCreate() {
+    // given
+    MenuItem menuItem = mock(MenuItem.class);
+    Tag tag1 = mock(Tag.class);
+    Tag tag2 = mock(Tag.class);
+    given(tagService.findAllByNames(anyList())).willReturn(List.of());
+    given(tagService.createNewTags(anyList())).willThrow(DataIntegrityViolationException.class);
+    given(tagService.findOrCreateTag("신규1")).willReturn(tag1);
+    given(tagService.findOrCreateTag("신규2")).willReturn(tag2);
+
+    // when
+    tagMappingService.createTagMappings(menuItem, List.of("신규1", "신규2"));
+
+    // then
+    then(tagService).should().findOrCreateTag("신규1");
+    then(tagService).should().findOrCreateTag("신규2");
+    then(tagMappingRepository).should().saveAll(anyList());
+  }
+
+  @Test
+  @DisplayName("menuItemId로 해당 메뉴 아이템의 TagMapping을 전체 삭제한다")
+  void deleteAllTagMappingByMenuItemId_deletesAllMappingsForMenuItem() {
+    // given
+    UUID menuItemId = UUID.randomUUID();
+
+    // when
+    tagMappingService.deleteAllTagMappingByMenuItemId(menuItemId);
+
+    // then
+    then(tagMappingRepository).should().deleteByMenuItemId(menuItemId);
+  }
+}

--- a/src/test/java/com/project/baedalsodae/tag/service/TagMappingServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/tag/service/TagMappingServiceImplTest.java
@@ -1,10 +1,7 @@
 package com.project.baedalsodae.tag.service;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
@@ -13,7 +10,6 @@ import com.project.baedalsodae.tag.entity.Tag;
 import com.project.baedalsodae.tag.repository.TagMappingRepository;
 import com.project.baedalsodae.tag.service.Impl.TagMappingServiceImpl;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class TagMappingServiceImplTest {
@@ -36,61 +31,40 @@ class TagMappingServiceImplTest {
   private TagMappingServiceImpl tagMappingService;
 
   @Test
-  @DisplayName("모든 태그가 이미 존재하면 배치 생성 없이 TagMapping을 저장한다")
-  void createTagMappings_whenAllTagsExist_savesWithoutBatchCreation() {
+  @DisplayName("태그를 upsert 후 전체 조회하여 TagMapping을 저장한다")
+  void createTagMappings_upsertAndSaveMappings() {
     // given
     MenuItem menuItem = mock(MenuItem.class);
     Tag tag1 = mock(Tag.class);
     Tag tag2 = mock(Tag.class);
     given(tag1.getName()).willReturn("치킨");
     given(tag2.getName()).willReturn("피자");
-    given(tagService.findAllByNames(anyList())).willReturn(List.of(tag1, tag2));
+    given(tagService.findAllByNames(List.of("치킨", "피자"))).willReturn(List.of(tag1, tag2));
 
     // when
     tagMappingService.createTagMappings(menuItem, List.of("치킨", "피자"));
 
     // then
-    then(tagService).should(never()).createNewTags(anyList());
+    then(tagService).should().createNewTagsIfNotExists(List.of("치킨", "피자"));
+    then(tagService).should().findAllByNames(List.of("치킨", "피자"));
     then(tagMappingRepository).should().saveAll(anyList());
   }
 
   @Test
-  @DisplayName("신규 태그가 있으면 배치 생성 후 TagMapping을 저장한다")
-  void createTagMappings_addsNewTagsAndSavesMappings() {
+  @DisplayName("중복 태그명이 포함된 경우 distinct 처리 후 upsert하고 TagMapping은 원본 순서대로 저장한다")
+  void createTagMappings_withDuplicateTagNames_distinctBeforeUpsert() {
     // given
     MenuItem menuItem = mock(MenuItem.class);
-    Tag existingTag = mock(Tag.class);
-    Tag newTag = mock(Tag.class);
-    given(existingTag.getName()).willReturn("치킨");
-    given(tagService.findAllByNames(anyList())).willReturn(List.of(existingTag));
-    given(tagService.createNewTags(List.of("피자"))).willReturn(Map.of("피자", newTag));
+    Tag tag = mock(Tag.class);
+    given(tag.getName()).willReturn("치킨");
+    given(tagService.findAllByNames(List.of("치킨"))).willReturn(List.of(tag));
 
     // when
-    tagMappingService.createTagMappings(menuItem, List.of("치킨", "피자"));
+    tagMappingService.createTagMappings(menuItem, List.of("치킨", "치킨"));
 
     // then
-    then(tagService).should().createNewTags(List.of("피자"));
-    then(tagMappingRepository).should().saveAll(anyList());
-  }
-
-  @Test
-  @DisplayName("배치 생성 중 동시 충돌 발생 시 개별 findOrCreateTag로 fallback 처리한다")
-  void createTagMappings_batchCreationConflict_fallbackToFindOrCreate() {
-    // given
-    MenuItem menuItem = mock(MenuItem.class);
-    Tag tag1 = mock(Tag.class);
-    Tag tag2 = mock(Tag.class);
-    given(tagService.findAllByNames(anyList())).willReturn(List.of());
-    given(tagService.createNewTags(anyList())).willThrow(DataIntegrityViolationException.class);
-    given(tagService.findOrCreateTag("신규1")).willReturn(tag1);
-    given(tagService.findOrCreateTag("신규2")).willReturn(tag2);
-
-    // when
-    tagMappingService.createTagMappings(menuItem, List.of("신규1", "신규2"));
-
-    // then
-    then(tagService).should().findOrCreateTag("신규1");
-    then(tagService).should().findOrCreateTag("신규2");
+    then(tagService).should().createNewTagsIfNotExists(List.of("치킨"));
+    then(tagService).should().findAllByNames(List.of("치킨"));
     then(tagMappingRepository).should().saveAll(anyList());
   }
 

--- a/src/test/java/com/project/baedalsodae/tag/service/TagServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/tag/service/TagServiceImplTest.java
@@ -1,32 +1,27 @@
 package com.project.baedalsodae.tag.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 import com.project.baedalsodae.tag.entity.Tag;
+import com.project.baedalsodae.tag.repository.TagBulkRepository;
 import com.project.baedalsodae.tag.repository.TagRepository;
 import com.project.baedalsodae.tag.service.Impl.TagServiceImpl;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class TagServiceImplTest {
 
   @Mock private TagRepository tagRepository;
+  @Mock private TagBulkRepository tagBulkRepository;
 
   @InjectMocks private TagServiceImpl tagService;
 
@@ -47,59 +42,15 @@ class TagServiceImplTest {
   }
 
   @Test
-  @DisplayName("신규 태그 목록을 단일 배치 INSERT로 저장하고 Map으로 반환한다")
-  void createNewTags_saveNewTagsInBatchAndReturnMap() {
+  @DisplayName("태그 이름 목록을 ON CONFLICT DO NOTHING으로 벌크 insert한다")
+  void createNewTagsIfNotExists_bulkInsertWithConflictIgnore() {
     // given
-    given(tagRepository.saveAllAndFlush(anyList())).willReturn(List.of());
+    List<String> names = List.of("치킨", "피자");
 
     // when
-    Map<String, Tag> result = tagService.createNewTags(List.of("새태그1", "새태그2"));
+    tagService.createNewTagsIfNotExists(names);
 
     // then
-    assertThat(result).containsKeys("새태그1", "새태그2");
-    then(tagRepository).should().saveAllAndFlush(anyList());
-  }
-
-  @Test
-  @DisplayName("배치 저장 중 동시 충돌 발생 시 DataIntegrityViolationException을 그대로 전파한다")
-  void createNewTags_whenBatchSaveConflict_thenThrowDataIntegrityViolationException() {
-    // given
-    given(tagRepository.saveAllAndFlush(anyList()))
-        .willThrow(DataIntegrityViolationException.class);
-
-    // when & then
-    assertThatThrownBy(() -> tagService.createNewTags(List.of("중복태그")))
-        .isInstanceOf(DataIntegrityViolationException.class);
-  }
-
-  @Test
-  @DisplayName("태그가 이미 존재하면 저장 없이 기존 태그를 반환한다")
-  void findOrCreateTag_whenTagExists_thenReturnExistingTagWithoutSaving() {
-    // given
-    Tag existingTag = mock(Tag.class);
-    given(tagRepository.findByName("치킨")).willReturn(Optional.of(existingTag));
-
-    // when
-    Tag result = tagService.findOrCreateTag("치킨");
-
-    // then
-    assertThat(result).isEqualTo(existingTag);
-    then(tagRepository).should(never()).saveAndFlush(any());
-  }
-
-  @Test
-  @DisplayName("태그가 없으면 새로 생성하여 반환한다")
-  void findOrCreateTag_whenTagDoesNotExist_thenCreateAndReturnNewTag() {
-    // given
-    Tag savedTag = mock(Tag.class);
-    given(tagRepository.findByName("신규태그")).willReturn(Optional.empty());
-    given(tagRepository.saveAndFlush(any(Tag.class))).willReturn(savedTag);
-
-    // when
-    Tag result = tagService.findOrCreateTag("신규태그");
-
-    // then
-    assertThat(result).isEqualTo(savedTag);
-    then(tagRepository).should().saveAndFlush(any(Tag.class));
+    then(tagBulkRepository).should().bulkInsertIgnore(names);
   }
 }

--- a/src/test/java/com/project/baedalsodae/tag/service/TagServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/tag/service/TagServiceImplTest.java
@@ -1,0 +1,105 @@
+package com.project.baedalsodae.tag.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import com.project.baedalsodae.tag.entity.Tag;
+import com.project.baedalsodae.tag.repository.TagRepository;
+import com.project.baedalsodae.tag.service.Impl.TagServiceImpl;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceImplTest {
+
+  @Mock private TagRepository tagRepository;
+
+  @InjectMocks private TagServiceImpl tagService;
+
+  @Test
+  @DisplayName("이름 목록으로 기존 태그를 일괄 조회한다")
+  void findAllByNames_getExistingTagsByNames() {
+    // given
+    Tag tag1 = mock(Tag.class);
+    Tag tag2 = mock(Tag.class);
+    given(tagRepository.findAllByNameIn(List.of("치킨", "피자"))).willReturn(List.of(tag1, tag2));
+
+    // when
+    List<Tag> result = tagService.findAllByNames(List.of("치킨", "피자"));
+
+    // then
+    assertThat(result).containsExactly(tag1, tag2);
+    then(tagRepository).should().findAllByNameIn(List.of("치킨", "피자"));
+  }
+
+  @Test
+  @DisplayName("신규 태그 목록을 단일 배치 INSERT로 저장하고 Map으로 반환한다")
+  void createNewTags_saveNewTagsInBatchAndReturnMap() {
+    // given
+    given(tagRepository.saveAllAndFlush(anyList())).willReturn(List.of());
+
+    // when
+    Map<String, Tag> result = tagService.createNewTags(List.of("새태그1", "새태그2"));
+
+    // then
+    assertThat(result).containsKeys("새태그1", "새태그2");
+    then(tagRepository).should().saveAllAndFlush(anyList());
+  }
+
+  @Test
+  @DisplayName("배치 저장 중 동시 충돌 발생 시 DataIntegrityViolationException을 그대로 전파한다")
+  void createNewTags_whenBatchSaveConflict_thenThrowDataIntegrityViolationException() {
+    // given
+    given(tagRepository.saveAllAndFlush(anyList()))
+        .willThrow(DataIntegrityViolationException.class);
+
+    // when & then
+    assertThatThrownBy(() -> tagService.createNewTags(List.of("중복태그")))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  @DisplayName("태그가 이미 존재하면 저장 없이 기존 태그를 반환한다")
+  void findOrCreateTag_whenTagExists_thenReturnExistingTagWithoutSaving() {
+    // given
+    Tag existingTag = mock(Tag.class);
+    given(tagRepository.findByName("치킨")).willReturn(Optional.of(existingTag));
+
+    // when
+    Tag result = tagService.findOrCreateTag("치킨");
+
+    // then
+    assertThat(result).isEqualTo(existingTag);
+    then(tagRepository).should(never()).saveAndFlush(any());
+  }
+
+  @Test
+  @DisplayName("태그가 없으면 새로 생성하여 반환한다")
+  void findOrCreateTag_whenTagDoesNotExist_thenCreateAndReturnNewTag() {
+    // given
+    Tag savedTag = mock(Tag.class);
+    given(tagRepository.findByName("신규태그")).willReturn(Optional.empty());
+    given(tagRepository.saveAndFlush(any(Tag.class))).willReturn(savedTag);
+
+    // when
+    Tag result = tagService.findOrCreateTag("신규태그");
+
+    // then
+    assertThat(result).isEqualTo(savedTag);
+    then(tagRepository).should().saveAndFlush(any(Tag.class));
+  }
+}


### PR DESCRIPTION
### 📌 관련 이슈
- close #36 

### 💡 작업 내용                                                                                                                                                                                                                 - Tag, TagMapping 엔티티에 정적 팩토리 메서드(create) 추가                                                                                                                                                                     
- TagRepository, TagMappingRepository 구현                                                                                                                                                                                     
- findAllByNameIn — 이름 목록으로 태그 일괄 조회                                                                                                                                                                             
- deleteByMenuItemId — JPQL 벌크 삭제 쿼리                                                                                                                                                                                   
- TagService / TagMappingService 인터페이스 및 구현체 작성                                                                                                                                                                     
- TagMapping 생성 시 3단계 태그 resolve 전략 적용                                                                                                                                                                              
- menuItemId 기준 TagMapping 전체 삭제 기능 구현                                                                                                                                                                               
- TagServiceImplTest, TagMappingServiceImplTest 단위 테스트 작성  

### 🔍 변경 이유
- 메뉴 아이템에 태그를 연결·관리하는 기능이 필요하여 태그 생성 및 매핑 로직을 구현                                                                                                                                               
                  
### 📝 리뷰 포인트 (선택)
  태그 resolve 3단계 전략 (TagMappingServiceImpl.createTagMappings)
  1. 기존 태그 일괄 조회 — findAllByNameIn으로 DB에서 한 번에 조회
  2. 신규 태그 배치 INSERT — 없는 태그는 createNewTags로 단일 쿼리 저장
  3. 동시성 충돌 fallback — 배치 INSERT 중 DataIntegrityViolationException 발생 시 bulkquery 와 On Conflict Do Nothing 적용

### 🧠 기타 참고 사항
 - TagMapping.orderNo — 태그 목록의 순서를 보장하기 위해 입력 순서 인덱스를 그대로 저장
 - TagMappingRepository.deleteByMenuItemId — 영속성 컨텍스트와의 동기화를 위해 clearAutomatically = true, flushAutomatically = true 옵션 적용
 -https://codingjw.tistory.com/211 On Conflict Do Nothing 기능 관련 블로그 