### PR TITLE
Feat/43 store categories crud

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
+++ b/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
@@ -21,7 +21,10 @@ public enum ErrorCode {
     // user/signup
     USER_NOT_FOUND("U001", HttpStatus.NOT_FOUND, "유저가 없습니다"),
     USER_DUPLICATED_EMAIL("U002", HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
-    USER_DUPLICATED_PHONE_NUMBER("U003", HttpStatus.CONFLICT, "이미 가입된 전화번호입니다");
+    USER_DUPLICATED_PHONE_NUMBER("U003", HttpStatus.CONFLICT, "이미 가입된 전화번호입니다"),
+
+    // store-category
+    STORE_CATEGORY_NOT_FOUND("SC001", HttpStatus.NOT_FOUND, "가게 카테고리가 존재하지 않습니다");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/project/baedalsodae/global/common/dto/AuditInfoResponse.java
+++ b/src/main/java/com/project/baedalsodae/global/common/dto/AuditInfoResponse.java
@@ -1,0 +1,31 @@
+package com.project.baedalsodae.global.common.dto;
+
+import com.project.baedalsodae.global.common.entity.BaseAuditEntity;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+public class AuditInfoResponse {
+    private final UUID createdBy;
+    private final Instant createdAt;
+    private final UUID updatedBy;
+    private final Instant updatedAt;
+    private final UUID deletedBy;
+    private final Instant deletedAt;
+
+    private AuditInfoResponse(BaseAuditEntity entity) {
+        this.createdBy = entity.getCreatedBy();
+        this.createdAt = entity.getCreatedAt();
+        this.updatedBy = entity.getUpdatedBy();
+        this.updatedAt = entity.getUpdatedAt();
+        this.deletedBy = entity.getDeletedBy();
+        this.deletedAt = entity.getDeletedAt();
+    }
+
+    public static AuditInfoResponse fromEntity(BaseAuditEntity entity){
+        if (entity == null) return null;
+        return new AuditInfoResponse(entity);
+    }
+}

--- a/src/main/java/com/project/baedalsodae/global/common/entity/BaseAuditEntity.java
+++ b/src/main/java/com/project/baedalsodae/global/common/entity/BaseAuditEntity.java
@@ -3,7 +3,8 @@ package com.project.baedalsodae.global.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
+
+import java.time.Instant;
 import java.util.UUID;
 
 import lombok.Getter;
@@ -26,7 +27,7 @@ public class BaseAuditEntity extends BaseTimeEntity {
   private UUID updatedBy;
 
   @Column(name = "deleted_at")
-  private LocalDateTime deletedAt;
+  private Instant deletedAt;
 
   @Column(name = "deleted_by")
   private UUID deletedBy;
@@ -37,7 +38,7 @@ public class BaseAuditEntity extends BaseTimeEntity {
 
   public void softDelete(UUID userId) {
     this.isDeleted = true;
-    this.deletedAt = LocalDateTime.now();
+    this.deletedAt = Instant.now();
     this.deletedBy = userId;
   }
 

--- a/src/main/java/com/project/baedalsodae/global/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/project/baedalsodae/global/common/entity/BaseTimeEntity.java
@@ -3,7 +3,8 @@ package com.project.baedalsodae.global.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
+
+import java.time.Instant;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -16,9 +17,9 @@ public class BaseTimeEntity {
 
   @CreatedDate
   @Column(name = "created_at", updatable = false)
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   @LastModifiedDate
   @Column(name = "updated_at")
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }

--- a/src/main/java/com/project/baedalsodae/store/controller/StoreCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/store/controller/StoreCategoryController.java
@@ -1,0 +1,55 @@
+package com.project.baedalsodae.store.controller;
+
+import com.project.baedalsodae.global.common.ApiResponse;
+import com.project.baedalsodae.store.dto.request.CreateStoreCategoryRequest;
+import com.project.baedalsodae.store.dto.request.PatchStoreCategoryRequest;
+import com.project.baedalsodae.store.dto.response.StoreCategoryDetailResponse;
+import com.project.baedalsodae.store.dto.response.StoreCategoryListResponse;
+import com.project.baedalsodae.store.service.StoreCategoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/store-categories")
+public class StoreCategoryController {
+    private final StoreCategoryService storeCategoryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<StoreCategoryListResponse>> getStoreCategoryListForCustomer() {
+        StoreCategoryListResponse response = storeCategoryService.storeCategoryList();
+        return ResponseEntity.ok(ApiResponse.success("Store categories retrieved.", response));
+    }
+
+    @GetMapping("{/storeCategoryId}")
+    public ResponseEntity<ApiResponse<StoreCategoryDetailResponse>> getStoreCategoryDetail(
+            @PathVariable UUID storeCategoryId) {
+        StoreCategoryDetailResponse response = storeCategoryService.storeCategoryDetail(storeCategoryId);
+        return ResponseEntity.ok(ApiResponse.success("Store category detail retrieved.", response));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> createStoreCategory(
+            @RequestBody @Valid CreateStoreCategoryRequest request) {
+        storeCategoryService.createStoreCategory(request);
+        return ResponseEntity.ok(ApiResponse.success("Store category created."));
+    }
+
+    @PatchMapping("{/storeCategoryId}")
+    public ResponseEntity<ApiResponse<String>> patchStoreCategory(
+            @RequestBody @Valid PatchStoreCategoryRequest request, @PathVariable UUID storeCategoryId) {
+        storeCategoryService.patchStoreCategory(request, storeCategoryId);
+        return ResponseEntity.ok(ApiResponse.success("Store category patched."));
+    }
+
+    @DeleteMapping("{/storeCategoryId}")
+    public ResponseEntity<ApiResponse<String>> deleteStoreCategory(
+            @PathVariable UUID storeCategoryId) {
+        storeCategoryService.deleteStoreCategory(storeCategoryId);
+        return ResponseEntity.ok(ApiResponse.success("Store category deleted."));
+    }
+}

--- a/src/main/java/com/project/baedalsodae/store/controller/StoreCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/store/controller/StoreCategoryController.java
@@ -21,14 +21,14 @@ public class StoreCategoryController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<StoreCategoryListResponse>> getStoreCategoryListForCustomer() {
-        StoreCategoryListResponse response = storeCategoryService.storeCategoryList();
+        StoreCategoryListResponse response = storeCategoryService.getActiveStoreCategories();
         return ResponseEntity.ok(ApiResponse.success("Store categories retrieved.", response));
     }
 
     @GetMapping("{/storeCategoryId}")
     public ResponseEntity<ApiResponse<StoreCategoryDetailResponse>> getStoreCategoryDetail(
             @PathVariable UUID storeCategoryId) {
-        StoreCategoryDetailResponse response = storeCategoryService.storeCategoryDetail(storeCategoryId);
+        StoreCategoryDetailResponse response = storeCategoryService.getStoreCategoryDetail(storeCategoryId);
         return ResponseEntity.ok(ApiResponse.success("Store category detail retrieved.", response));
     }
 

--- a/src/main/java/com/project/baedalsodae/store/dto/request/CreateStoreCategoryRequest.java
+++ b/src/main/java/com/project/baedalsodae/store/dto/request/CreateStoreCategoryRequest.java
@@ -1,0 +1,18 @@
+package com.project.baedalsodae.store.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateStoreCategoryRequest {
+    @NotEmpty(message = "카테고리 이름은 필수입니다.")
+    @NotNull(message = "카테고리 이름은 필수입니다.")
+    private String name;
+
+    @Size(max = 200, message = "설명은 200자 이내로 작성해주세요.")
+    private String description;
+}

--- a/src/main/java/com/project/baedalsodae/store/dto/request/PatchStoreCategoryRequest.java
+++ b/src/main/java/com/project/baedalsodae/store/dto/request/PatchStoreCategoryRequest.java
@@ -1,0 +1,19 @@
+package com.project.baedalsodae.store.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PatchStoreCategoryRequest {
+    @NotEmpty
+    @NotNull
+    @Size(min = 2, max = 50)
+    private String name;
+
+    @Size(max = 200)
+    private String description;
+}

--- a/src/main/java/com/project/baedalsodae/store/dto/response/StoreCategoryDetailResponse.java
+++ b/src/main/java/com/project/baedalsodae/store/dto/response/StoreCategoryDetailResponse.java
@@ -1,0 +1,26 @@
+package com.project.baedalsodae.store.dto.response;
+
+import com.project.baedalsodae.global.common.dto.AuditInfoResponse;
+import com.project.baedalsodae.store.entity.StoreCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class StoreCategoryDetailResponse {
+    private UUID id;
+    private String name;
+    private String description;
+    private AuditInfoResponse auditInfo;
+
+    public static StoreCategoryDetailResponse fromStoreCategory(StoreCategory storeCategory) {
+        return StoreCategoryDetailResponse.builder()
+                .id(storeCategory.getId())
+                .name(storeCategory.getName())
+                .description(storeCategory.getDescription())
+                .auditInfo(AuditInfoResponse.fromEntity(storeCategory))
+                .build();
+    }
+}

--- a/src/main/java/com/project/baedalsodae/store/dto/response/StoreCategoryListResponse.java
+++ b/src/main/java/com/project/baedalsodae/store/dto/response/StoreCategoryListResponse.java
@@ -1,0 +1,19 @@
+package com.project.baedalsodae.store.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StoreCategoryListResponse {
+    private List<StoreCategoryResponse> storeCategoryList;
+    private int totalCount;
+
+    public static StoreCategoryListResponse fromList(List<StoreCategoryResponse> storeCategoryList) {
+        return StoreCategoryListResponse.builder()
+                .storeCategoryList(storeCategoryList)
+                .totalCount(storeCategoryList.size())
+                .build();
+    }
+}

--- a/src/main/java/com/project/baedalsodae/store/dto/response/StoreCategoryResponse.java
+++ b/src/main/java/com/project/baedalsodae/store/dto/response/StoreCategoryResponse.java
@@ -1,0 +1,21 @@
+package com.project.baedalsodae.store.dto.response;
+
+import com.project.baedalsodae.store.entity.StoreCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Builder
+@Getter
+public class StoreCategoryResponse {
+    private UUID id;
+    private String name;
+
+    public static StoreCategoryResponse from(StoreCategory storeCategory) {
+        return StoreCategoryResponse.builder()
+                .id(storeCategory.getId())
+                .name(storeCategory.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/project/baedalsodae/store/entity/Store.java
+++ b/src/main/java/com/project/baedalsodae/store/entity/Store.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 public class Store extends BaseAuditEntity {
 
     @Id

--- a/src/main/java/com/project/baedalsodae/store/entity/StoreCategory.java
+++ b/src/main/java/com/project/baedalsodae/store/entity/StoreCategory.java
@@ -1,6 +1,6 @@
 package com.project.baedalsodae.store.entity;
 
-import com.project.baedalsodae.global.common.entity.BaseTimeEntity;
+import com.project.baedalsodae.global.common.entity.BaseAuditEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 @Entity
 @Table(
-        name = "p_store",
+        name = "p_store_category",
         uniqueConstraints = {
                 @UniqueConstraint(name = "uq_store_business_number", columnNames = "business_number")
         }
@@ -16,8 +16,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
-public class StoreCategory extends BaseTimeEntity {
+public class StoreCategory extends BaseAuditEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "id", updatable = false, nullable = false)
@@ -25,4 +24,18 @@ public class StoreCategory extends BaseTimeEntity {
 
     @Column(name = "name", length = 50)
     private String name;
+
+    @Column(name = "description", length = 200)
+    private String description;
+
+    public void patchStoreCategory(String name, String description) {
+        if(name != null) {
+            this.name = name;
+        }
+        this.description = description;
+    }
+
+    public static StoreCategory createStoreCategory(String name, String description) {
+        return new StoreCategory(null, name, description);
+    }
 }

--- a/src/main/java/com/project/baedalsodae/store/entity/StoreHours.java
+++ b/src/main/java/com/project/baedalsodae/store/entity/StoreHours.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import java.time.DayOfWeek;
-import java.time.LocalTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -17,7 +17,6 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 public class StoreHours {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -34,16 +33,16 @@ public class StoreHours {
     private DayOfWeek dayOfWeek;
 
     @Column(name = "open_time")
-    private LocalTime openTime;
+    private Instant openTime;
 
     @Column(name = "close_time")
-    private LocalTime closeTime;
+    private Instant closeTime;
 
     @Column(name = "break_start")
-    private LocalTime breakStart;
+    private Instant breakStart;
 
     @Column(name = "break_end")
-    private LocalTime breakEnd;
+    private Instant breakEnd;
 
     @Column(name = "is_open", nullable = false)
     @ColumnDefault("true")

--- a/src/main/java/com/project/baedalsodae/store/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/project/baedalsodae/store/repository/StoreCategoryRepository.java
@@ -1,0 +1,13 @@
+package com.project.baedalsodae.store.repository;
+
+import com.project.baedalsodae.store.entity.StoreCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID> {
+    List<StoreCategory> findAllByIsDeletedFalse();
+}

--- a/src/main/java/com/project/baedalsodae/store/service/StoreCategoryService.java
+++ b/src/main/java/com/project/baedalsodae/store/service/StoreCategoryService.java
@@ -1,0 +1,17 @@
+package com.project.baedalsodae.store.service;
+
+import com.project.baedalsodae.store.dto.request.CreateStoreCategoryRequest;
+import com.project.baedalsodae.store.dto.request.PatchStoreCategoryRequest;
+import com.project.baedalsodae.store.dto.response.StoreCategoryDetailResponse;
+import com.project.baedalsodae.store.dto.response.StoreCategoryListResponse;
+
+import java.util.UUID;
+
+public interface StoreCategoryService {
+    StoreCategoryListResponse storeCategoryList();
+//    StoreCategoryListResponse storeCategoryList();
+    StoreCategoryDetailResponse storeCategoryDetail(UUID storeCategoryId);
+    void createStoreCategory(CreateStoreCategoryRequest request);
+    void patchStoreCategory(PatchStoreCategoryRequest request, UUID storeCategoryId);
+    void deleteStoreCategory(UUID storeCategoryId);
+}

--- a/src/main/java/com/project/baedalsodae/store/service/StoreCategoryService.java
+++ b/src/main/java/com/project/baedalsodae/store/service/StoreCategoryService.java
@@ -8,9 +8,8 @@ import com.project.baedalsodae.store.dto.response.StoreCategoryListResponse;
 import java.util.UUID;
 
 public interface StoreCategoryService {
-    StoreCategoryListResponse storeCategoryList();
-//    StoreCategoryListResponse storeCategoryList();
-    StoreCategoryDetailResponse storeCategoryDetail(UUID storeCategoryId);
+    StoreCategoryListResponse getActiveStoreCategories();
+    StoreCategoryDetailResponse getStoreCategoryDetail(UUID storeCategoryId);
     void createStoreCategory(CreateStoreCategoryRequest request);
     void patchStoreCategory(PatchStoreCategoryRequest request, UUID storeCategoryId);
     void deleteStoreCategory(UUID storeCategoryId);

--- a/src/main/java/com/project/baedalsodae/store/service/impl/StoreCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/store/service/impl/StoreCategoryServiceImpl.java
@@ -23,7 +23,7 @@ public class StoreCategoryServiceImpl implements StoreCategoryService {
     private final StoreCategoryRepository storeCategoryRepository;
 
     @Override
-    public StoreCategoryListResponse storeCategoryList() {
+    public StoreCategoryListResponse getActiveStoreCategories() {
         List<StoreCategoryResponse> storeCategoryResponseList = storeCategoryRepository.findAllByIsDeletedFalse()
                 .stream()
                 .map(StoreCategoryResponse::from)
@@ -33,8 +33,9 @@ public class StoreCategoryServiceImpl implements StoreCategoryService {
     }
 
     @Override
-    public StoreCategoryDetailResponse storeCategoryDetail(UUID storeCategoryId) {
-        return null;
+    public StoreCategoryDetailResponse getStoreCategoryDetail(UUID storeCategoryId) {
+        StoreCategory storeCategory = getStoreCategory(storeCategoryId);
+        return StoreCategoryDetailResponse.fromStoreCategory(storeCategory);
     }
 
     @Override

--- a/src/main/java/com/project/baedalsodae/store/service/impl/StoreCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/store/service/impl/StoreCategoryServiceImpl.java
@@ -1,0 +1,67 @@
+package com.project.baedalsodae.store.service.impl;
+
+import com.project.baedalsodae.global.common.BusinessException;
+import com.project.baedalsodae.global.common.ErrorCode;
+import com.project.baedalsodae.store.dto.request.CreateStoreCategoryRequest;
+import com.project.baedalsodae.store.dto.request.PatchStoreCategoryRequest;
+import com.project.baedalsodae.store.dto.response.StoreCategoryDetailResponse;
+import com.project.baedalsodae.store.dto.response.StoreCategoryListResponse;
+import com.project.baedalsodae.store.dto.response.StoreCategoryResponse;
+import com.project.baedalsodae.store.entity.StoreCategory;
+import com.project.baedalsodae.store.repository.StoreCategoryRepository;
+import com.project.baedalsodae.store.service.StoreCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class StoreCategoryServiceImpl implements StoreCategoryService {
+    private final StoreCategoryRepository storeCategoryRepository;
+
+    @Override
+    public StoreCategoryListResponse storeCategoryList() {
+        List<StoreCategoryResponse> storeCategoryResponseList = storeCategoryRepository.findAllByIsDeletedFalse()
+                .stream()
+                .map(StoreCategoryResponse::from)
+                .toList();
+
+        return StoreCategoryListResponse.fromList(storeCategoryResponseList);
+    }
+
+    @Override
+    public StoreCategoryDetailResponse storeCategoryDetail(UUID storeCategoryId) {
+        return null;
+    }
+
+    @Override
+    public void createStoreCategory(CreateStoreCategoryRequest request) {
+        StoreCategory storeCategory =
+                StoreCategory.createStoreCategory(request.getName(), request.getDescription());
+        storeCategoryRepository.save(storeCategory);
+    }
+
+    @Override
+    @Transactional
+    public void patchStoreCategory(PatchStoreCategoryRequest request, UUID storeCategoryId) {
+        StoreCategory storeCategory = getStoreCategory(storeCategoryId);
+        storeCategory.patchStoreCategory(request.getName(), request.getDescription());
+    }
+
+    @Override
+    @Transactional
+    public void deleteStoreCategory(UUID storeCategoryId) {
+        StoreCategory storeCategory = getStoreCategory(storeCategoryId);
+        storeCategory.softDelete(storeCategoryId);
+    }
+
+    private StoreCategory getStoreCategory(UUID StoreCategoryId) {
+        return storeCategoryRepository.findById(StoreCategoryId)
+                .orElseThrow(()->new BusinessException(ErrorCode.STORE_CATEGORY_NOT_FOUND));
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,5 @@ spring:
 
 server:
   port: 8080
+  servlet:
+    context-path: /api/v1


### PR DESCRIPTION
### 📌 관련 이슈
- close #43

### 💡 작업 내용
- 공통 API 경로(`'/api/v1'`) yml 파일로 이동
- 서버 시간 일관성을 위해 가게 관련 엔티티와 공통 엔티티의 LocalDateTime 을 Instant 로 변경
- 관리자 엔티티 감사 정보 관리를 위한 공통 `AuditInfoResponse `추가
- 가게 카테고리 리스트 조회, 상세 조회, 생성, 수정, 삭제 기능 추가

### 🔍 변경 이유
- 서버/DB 간 시간대 차이로 인한 데이터 불일치 가능성을 방지하고, UTC 기반 시간 관리를 통해 일관성을 확보하기 위함
- 감사 정보 응답 구조를 공통화하여 향후 다른 도메인에서도 재사용 가능하도록 확장성을 고려함
- 가게 카테고리 도메인에 대한 기본 CRUD 기능을 제공하기 위함

### 📝 리뷰 포인트 (선택)
- AuditInfoResponse를 공통 DTO로 두는 구조가 향후 확장에 적합한지
- StoreCategory 관련 DTO 구성 및 책임 분리가 적절한지
- 예외 처리 방식(ErrorCode 기반)이 일관되게 적용되었는지

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)