### PR TITLE
fix: localdateTime 을 Instant로 변경

### DIFF
--- a/src/main/java/com/project/baedalsodae/global/common/entity/BaseAuditEntity.java
+++ b/src/main/java/com/project/baedalsodae/global/common/entity/BaseAuditEntity.java
@@ -3,6 +3,8 @@ package com.project.baedalsodae.global.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -26,7 +28,7 @@ public class BaseAuditEntity extends BaseTimeEntity {
   private UUID updatedBy;
 
   @Column(name = "deleted_at")
-  private LocalDateTime deletedAt;
+  private Instant deletedAt;
 
   @Column(name = "deleted_by")
   private UUID deletedBy;
@@ -37,7 +39,7 @@ public class BaseAuditEntity extends BaseTimeEntity {
 
   public void softDelete(UUID userId) {
     this.isDeleted = true;
-    this.deletedAt = LocalDateTime.now();
+    this.deletedAt = Instant.now();
     this.deletedBy = userId;
   }
 

--- a/src/main/java/com/project/baedalsodae/global/common/entity/BaseAuditEntity.java
+++ b/src/main/java/com/project/baedalsodae/global/common/entity/BaseAuditEntity.java
@@ -3,11 +3,10 @@ package com.project.baedalsodae.global.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.UUID;
-
 import lombok.Getter;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedBy;
@@ -47,5 +46,9 @@ public class BaseAuditEntity extends BaseTimeEntity {
     this.isDeleted = false;
     this.deletedAt = null;
     this.deletedBy = null;
+  }
+
+  public LocalDateTime getLocalDateDeletedAt() {
+    return deletedAt != null ? LocalDateTime.ofInstant(deletedAt, ZoneId.systemDefault()) : null;
   }
 }

--- a/src/main/java/com/project/baedalsodae/global/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/project/baedalsodae/global/common/entity/BaseTimeEntity.java
@@ -3,7 +3,7 @@ package com.project.baedalsodae.global.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -16,9 +16,9 @@ public class BaseTimeEntity {
 
   @CreatedDate
   @Column(name = "created_at", updatable = false)
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   @LastModifiedDate
   @Column(name = "updated_at")
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }

--- a/src/main/java/com/project/baedalsodae/global/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/project/baedalsodae/global/common/entity/BaseTimeEntity.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -21,4 +23,12 @@ public class BaseTimeEntity {
   @LastModifiedDate
   @Column(name = "updated_at")
   private Instant updatedAt;
+
+  public LocalDateTime getLocalDateCreatedAt() {
+    return createdAt != null ? LocalDateTime.ofInstant(createdAt, ZoneId.systemDefault()) : null;
+  }
+
+  public LocalDateTime getLocalDateUpdatedAt() {
+    return updatedAt != null ? LocalDateTime.ofInstant(updatedAt, ZoneId.systemDefault()) : null;
+  }
 }

--- a/src/main/java/com/project/baedalsodae/user/dto/response/UserResponseDto.java
+++ b/src/main/java/com/project/baedalsodae/user/dto/response/UserResponseDto.java
@@ -41,8 +41,8 @@ public class UserResponseDto {
                     .name(user.getName())
                     .nickname(user.getNickname())
                     .role(user.getRole())
-                    .createdAt(user.getCreatedAt())
-                    .updatedAt(user.getUpdatedAt())
+                    .createdAt(user.getLocalDateCreatedAt())
+                    .updatedAt(user.getLocalDateUpdatedAt())
                     .createdBy(user.getCreatedBy())
                     .updatedBy(user.getUpdatedBy())
                     .build();
@@ -62,7 +62,7 @@ public class UserResponseDto {
         public static Delete from(User user) {
             return Delete.builder()
                     .id(user.getId())
-                    .deletedAt(user.getDeletedAt())
+                    .deletedAt(user.getLocalDateDeletedAt())
                     .deletedBy(user.getDeletedBy())
                     .build();
         }


### PR DESCRIPTION
### 📌 관련 이슈
- close #53 

### 💡 작업 내용
- LocalDateTime 을 Instant 로 변경 
- Instant → LocalDateTime 변환 편의 메서드 추가 (getLocalDateCreatedAt, getLocalDateUpdatedAt, getLocalDateDeletedAt)
- UserResponseDto에서 변환 메서드를 통해 LocalDateTime으로 응답하도록 수정


### 🔍 변경 이유
- 타임존 의존성 제거 (UTC 기준 절대 시간 사용)
- MSA 환경에서 시간 일관성 확보
- 서버/배포 환경 차이로 인한 시간 오류 방지

### 📝 리뷰 포인트 (선택)
- LocalDateTime 변환 편의 메서드에서 ZoneId.systemDefault()를 사용하고 있어 서버 환경 시간대에 의존함. 명시적 시간대 고정 여부 논의 필요
- 응답 DTO에서 Instant를 직접 노출할지, LocalDateTime으로 변환하여 노출할지 팀 컨벤션 정의 필요


### 🧠 기타 참고 사항
