### PR TITLE
Feat/60 get tags

### DIFF
--- a/src/main/java/com/project/baedalsodae/tag/controller/TagController.java
+++ b/src/main/java/com/project/baedalsodae/tag/controller/TagController.java
@@ -1,0 +1,28 @@
+package com.project.baedalsodae.tag.controller;
+
+import com.project.baedalsodae.global.common.ApiResponse;
+import com.project.baedalsodae.tag.dto.responseDto.TagResponseDto;
+import com.project.baedalsodae.tag.service.TagService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tags")
+public class TagController {
+
+  private final TagService tagService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<TagResponseDto>>> getTagListByParams(
+      @RequestParam(required = false) String keyword,
+      @RequestParam(defaultValue = "10") Integer count) {
+    List<TagResponseDto> response = tagService.getTagListByParams(keyword, count);
+    return ResponseEntity.ok(ApiResponse.success("", response));
+  }
+}

--- a/src/main/java/com/project/baedalsodae/tag/dto/responseDto/TagResponseDto.java
+++ b/src/main/java/com/project/baedalsodae/tag/dto/responseDto/TagResponseDto.java
@@ -1,0 +1,10 @@
+package com.project.baedalsodae.tag.dto.responseDto;
+
+import com.project.baedalsodae.tag.entity.Tag;
+import java.util.UUID;
+
+public record TagResponseDto(UUID id, String name) {
+  public static TagResponseDto fromEntity(Tag tag) {
+    return new TagResponseDto(tag.getId(), tag.getName());
+  }
+}

--- a/src/main/java/com/project/baedalsodae/tag/repository/TagRepository.java
+++ b/src/main/java/com/project/baedalsodae/tag/repository/TagRepository.java
@@ -3,13 +3,38 @@ package com.project.baedalsodae.tag.repository;
 import com.project.baedalsodae.tag.entity.Tag;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TagRepository extends JpaRepository<Tag, UUID> {
 
-  Optional<Tag> findByName(String name);
-
   List<Tag> findAllByNameIn(Collection<String> names);
+
+  @Query(
+      value =
+          """
+                  SELECT t.* FROM p_tag t
+                  LEFT JOIN p_tag_mapping tm ON t.id = tm.tag_id
+                  GROUP BY t.id
+                  ORDER BY COUNT(tm.id) DESC
+                  LIMIT :count
+                  """,
+      nativeQuery = true)
+  List<Tag> findTopByMappingCount(int count);
+
+  @Query(
+      value =
+          """
+                  SELECT t.* FROM p_tag t
+                  LEFT JOIN p_tag_mapping tm ON t.id = tm.tag_id
+                  WHERE LOWER(t.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                  GROUP BY t.id
+                  ORDER BY
+                      CASE WHEN LOWER(t.name) LIKE LOWER(CONCAT(:keyword, '%')) THEN 0 ELSE 1 END,
+                      COUNT(tm.id) DESC
+                  LIMIT :count
+                  """,
+      nativeQuery = true)
+  List<Tag> findByKeywordOrderByRelevance(String keyword, int count);
 }

--- a/src/main/java/com/project/baedalsodae/tag/service/Impl/TagServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/Impl/TagServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.baedalsodae.tag.service.Impl;
 
+import com.project.baedalsodae.tag.dto.responseDto.TagResponseDto;
 import com.project.baedalsodae.tag.entity.Tag;
 import com.project.baedalsodae.tag.repository.TagBulkRepository;
 import com.project.baedalsodae.tag.repository.TagRepository;
@@ -26,5 +27,16 @@ public class TagServiceImpl implements TagService {
   public void createNewTagsIfNotExists(List<String> tagNames) {
     List<String> distinctNames = tagNames.stream().distinct().toList();
     tagBulkRepository.bulkInsertIgnore(distinctNames);
+  }
+
+  @Transactional(readOnly = true)
+  @Override
+  public List<TagResponseDto> getTagListByParams(String keyword, int count) {
+    List<Tag> tags;
+    if (keyword == null || keyword.isBlank()) {
+      tags = tagRepository.findTopByMappingCount(count);
+    } else tags = tagRepository.findByKeywordOrderByRelevance(keyword, count);
+
+    return tags.stream().map(TagResponseDto::fromEntity).toList();
   }
 }

--- a/src/main/java/com/project/baedalsodae/tag/service/TagService.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/TagService.java
@@ -1,12 +1,14 @@
 package com.project.baedalsodae.tag.service;
 
+import com.project.baedalsodae.tag.dto.responseDto.TagResponseDto;
 import com.project.baedalsodae.tag.entity.Tag;
 import java.util.List;
-import java.util.Map;
 
 public interface TagService {
 
   List<Tag> findAllByNames(List<String> names);
 
   void createNewTagsIfNotExists(List<String> distinctNames);
+
+  List<TagResponseDto> getTagListByParams(String keyword, int count);
 }

--- a/src/test/java/com/project/baedalsodae/tag/service/TagServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/tag/service/TagServiceImplTest.java
@@ -1,15 +1,22 @@
 package com.project.baedalsodae.tag.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import com.project.baedalsodae.tag.dto.responseDto.TagResponseDto;
 import com.project.baedalsodae.tag.entity.Tag;
 import com.project.baedalsodae.tag.repository.TagBulkRepository;
 import com.project.baedalsodae.tag.repository.TagRepository;
 import com.project.baedalsodae.tag.service.Impl.TagServiceImpl;
 import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,40 +24,127 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@Slf4j
 @ExtendWith(MockitoExtension.class)
 class TagServiceImplTest {
 
   @Mock private TagRepository tagRepository;
   @Mock private TagBulkRepository tagBulkRepository;
 
+  @Mock private Tag tag1;
+  @Mock private Tag tag2;
+
   @InjectMocks private TagServiceImpl tagService;
 
   @Test
-  @DisplayName("이름 목록으로 기존 태그를 일괄 조회한다")
+  @DisplayName("이름 목록이 주어지면 일치하는 태그 목록을 반환한다")
   void findAllByNames_getExistingTagsByNames() {
     // given
-    Tag tag1 = mock(Tag.class);
-    Tag tag2 = mock(Tag.class);
     given(tagRepository.findAllByNameIn(List.of("치킨", "피자"))).willReturn(List.of(tag1, tag2));
 
     // when
     List<Tag> result = tagService.findAllByNames(List.of("치킨", "피자"));
+    log.info("result = {}", result);
 
     // then
     assertThat(result).containsExactly(tag1, tag2);
-    then(tagRepository).should().findAllByNameIn(List.of("치킨", "피자"));
+    verify(tagRepository).findAllByNameIn(List.of("치킨", "피자"));
   }
 
   @Test
-  @DisplayName("태그 이름 목록을 ON CONFLICT DO NOTHING으로 벌크 insert한다")
-  void createNewTagsIfNotExists_bulkInsertWithConflictIgnore() {
+  @DisplayName("태그 이름 목록에 중복이 있으면 중복을 제거한 후 벌크 insert한다")
+  void createNewTagsIfNotExists_deduplicatesBeforeBulkInsert() {
     // given
-    List<String> names = List.of("치킨", "피자");
+    List<String> namesWithDuplicate = List.of("치킨", "피자", "치킨");
 
     // when
-    tagService.createNewTagsIfNotExists(names);
+    tagService.createNewTagsIfNotExists(namesWithDuplicate);
 
     // then
-    then(tagBulkRepository).should().bulkInsertIgnore(names);
+    verify(tagBulkRepository).bulkInsertIgnore(List.of("치킨", "피자"));
+  }
+
+  @Test
+  @DisplayName("keyword가 null이면 태그 목록을 TagResponseDto로 변환하여 반환한다")
+  void getTagListByParams_whenKeywordIsNull_returnsTagResponseDtos() {
+    // given
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+    given(tag1.getId()).willReturn(id1);
+    given(tag1.getName()).willReturn("매운맛");
+    given(tag2.getId()).willReturn(id2);
+    given(tag2.getName()).willReturn("인기");
+    given(tagRepository.findTopByMappingCount(10)).willReturn(List.of(tag1, tag2));
+
+    // when
+    List<TagResponseDto> result = tagService.getTagListByParams(null, 10);
+    log.info("result = {}", result);
+
+    // then
+    assertThat(result)
+        .extracting(TagResponseDto::id, TagResponseDto::name)
+        .containsExactly(tuple(id1, "매운맛"), tuple(id2, "인기"));
+    verify(tagRepository).findTopByMappingCount(10);
+    then(tagRepository).should(never()).findByKeywordOrderByRelevance(any(), anyInt());
+  }
+
+  @Test
+  @DisplayName("keyword가 공백 문자열이면 null과 동일하게 처리한다")
+  void getTagListByParams_whenKeywordIsBlank_treatedSameAsNull() {
+    // given
+    UUID id1 = UUID.randomUUID();
+    given(tag1.getId()).willReturn(id1);
+    given(tag1.getName()).willReturn("매운맛");
+    given(tagRepository.findTopByMappingCount(10)).willReturn(List.of(tag1));
+
+    // when
+    List<TagResponseDto> result = tagService.getTagListByParams("   ", 10);
+    log.info("result = {}", result);
+
+    // then
+    assertThat(result)
+        .extracting(TagResponseDto::id, TagResponseDto::name)
+        .containsExactly(tuple(id1, "매운맛"));
+    verify(tagRepository).findTopByMappingCount(10);
+    then(tagRepository).should(never()).findByKeywordOrderByRelevance(any(), anyInt());
+  }
+
+  @Test
+  @DisplayName("keyword가 있으면 해당 keyword로 태그를 조회하여 TagResponseDto로 반환한다")
+  void getTagListByParams_whenKeywordIsPresent_returnsTagResponseDtos() {
+    // given
+    String keyword = "매운";
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+    given(tag1.getId()).willReturn(id1);
+    given(tag1.getName()).willReturn("매운맛");
+    given(tag2.getId()).willReturn(id2);
+    given(tag2.getName()).willReturn("아주매운닭갈비");
+    given(tagRepository.findByKeywordOrderByRelevance(keyword, 10)).willReturn(List.of(tag1, tag2));
+
+    // when
+    List<TagResponseDto> result = tagService.getTagListByParams(keyword, 10);
+    log.info("result = {}", result);
+
+    // then
+    assertThat(result)
+        .extracting(TagResponseDto::id, TagResponseDto::name)
+        .containsExactly(tuple(id1, "매운맛"), tuple(id2, "아주매운닭갈비"));
+    verify(tagRepository).findByKeywordOrderByRelevance(keyword, 10);
+    then(tagRepository).should(never()).findTopByMappingCount(anyInt());
+  }
+
+  @Test
+  @DisplayName("keyword와 일치하는 태그가 없으면 빈 리스트를 반환한다")
+  void getTagListByParams_whenNoResult_returnsEmptyList() {
+    // given
+    given(tagRepository.findByKeywordOrderByRelevance("없는태그", 10)).willReturn(List.of());
+
+    // when
+    List<TagResponseDto> result = tagService.getTagListByParams("없는태그", 10);
+    log.info("result = {}", result);
+
+    // then
+    assertThat(result).isEmpty();
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #60
- 
### 💡 작업 내용
- 키워드 입력시 키워드로 시작하거나 글을 모두 포함한 태그 리스트 반환
- 키워드 입력하지 않았을 시 태그 매핑이 가장 많이 이루어진 태그부터 순차적으로 반환

### 🔍 변경 이유


### 📝 리뷰 포인트 (선택)
- 각 검색 관련 Native Query 사용 하였는데 이에대한 피드백 

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)