### PR TITLE
Feat/47 menuitem create and update

### DIFF
--- a/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
+++ b/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
@@ -53,4 +53,5 @@ public enum ErrorCode {
 	private final HttpStatus status;
 	private final String message;
 
+
 }

--- a/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
+++ b/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
@@ -32,26 +32,29 @@ public enum ErrorCode {
 	// menu-category
 	MENU_CATEGORY_NOT_FOUND("MC001", HttpStatus.NOT_FOUND, "메뉴 카테고리가 없습니다"),
 	INVALID_MENU_CATEGORY_ORDER("MC002", HttpStatus.BAD_REQUEST, "메뉴 카테고리 순서가 잘못됐습니다."),
+	DUPLICATE_MENU_CATEGORY_NAME("MC003", HttpStatus.CONFLICT, "같은 가게에 같은 이름의 메뉴 카테고리가 존재합니다"),
 
 	// menuItem
 	MENU_ITEM_NOT_FOUND("MI001", HttpStatus.NOT_FOUND, "메뉴 아이템이 없습니다"),
+	INVALID_MENU_ITEM_ORDER("MI002", HttpStatus.BAD_REQUEST, "메뉴 순서가 유효하지 않습니다"),
+	DUPLICATE_MENU_ITEM_NAME("MI003", HttpStatus.CONFLICT, "같은 카테고리에 같은 이름의 메뉴 아이템이 존재합니다"),
+	MENU_ITEM_ORDER_CONFLICT("MI004", HttpStatus.CONFLICT, "메뉴 아이템 순서가 충돌했습니다. 다시 시도해주세요."),
 
 	// cart
 	CART_NOT_FOUND("CT001", HttpStatus.NOT_FOUND, "장바구니가 없습니다."),
 	CART_INVALID_QUANTITY("CT002", HttpStatus.BAD_REQUEST, "수량은 1 이상이어야 합니다."),
 	CART_DIFFERENT_STORE("CT003", HttpStatus.BAD_REQUEST, "다른 가게의 메뉴는 담을 수 없습니다."),
 	CART_ITEM_NOT_FOUND("CT004", HttpStatus.NOT_FOUND, "장바구니 아이템이 없습니다."),
-    CART_ITEM_EMPTY("CT004", HttpStatus.NOT_FOUND, "장바구니 아이템이 비어있습니다."),
+	CART_ITEM_EMPTY("CT004", HttpStatus.NOT_FOUND, "장바구니 아이템이 비어있습니다."),
 
-    //order
-    ORDER_INVALID_TOTAL_AMOUNT("OD001", HttpStatus.BAD_REQUEST, "총 메뉴 금액이 올바르지 않습니다."),
-    ORDER_INVALID_FINAL_AMOUNT("OD002", HttpStatus.BAD_REQUEST, "총 결제 금액이 올바르지 않습니다."),
+	//order
+	ORDER_INVALID_TOTAL_AMOUNT("OD001", HttpStatus.BAD_REQUEST, "총 메뉴 금액이 올바르지 않습니다."),
+	ORDER_INVALID_FINAL_AMOUNT("OD002", HttpStatus.BAD_REQUEST, "총 결제 금액이 올바르지 않습니다."),
 
 	;
 
 	private final String code;
 	private final HttpStatus status;
 	private final String message;
-
 
 }

--- a/src/main/java/com/project/baedalsodae/menu/common/OrderUtil.java
+++ b/src/main/java/com/project/baedalsodae/menu/common/OrderUtil.java
@@ -3,7 +3,7 @@ package com.project.baedalsodae.menu.common;
 import java.util.List;
 
 public class OrderUtil {
-  public static <T extends Orderable> void shiftBetween(
+  private static <T extends Orderable> void shiftBetween(
       List<T> items, int sourceOrderNo, int targetOrderNo) {
     boolean isMovingDown = sourceOrderNo < targetOrderNo;
 

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -50,4 +50,11 @@ public class MenuCategoryController {
     MenuItemResponseDto response = menuItemService.createMenuItem(menuCategoryId, request);
     return ResponseEntity.ok(ApiResponse.success("", response));
   }
+
+  @GetMapping("/{menuCategoryId}/menu-items/duplicate-check")
+  public ResponseEntity<ApiResponse<Boolean>> checkDuplicateMenuItemName(
+      @PathVariable UUID menuCategoryId, @RequestParam String name) {
+    boolean isDuplicate = menuItemService.isDuplicateMenuItemName(menuCategoryId, name);
+    return ResponseEntity.ok(ApiResponse.success("", isDuplicate));
+  }
 }

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -3,8 +3,11 @@ package com.project.baedalsodae.menu.controller;
 import com.project.baedalsodae.global.common.ApiResponse;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
+import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPostRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
+import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
 import com.project.baedalsodae.menu.service.MenuCategoryService;
+import com.project.baedalsodae.menu.service.MenuItemService;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class MenuCategoryController {
 
   private final MenuCategoryService menuCategoryService;
+  private final MenuItemService menuItemService;
 
   @PutMapping("/{menuCategoryId}")
   public ResponseEntity<ApiResponse<MenuCategoryResponseDto>> updateMenuCategory(
@@ -38,5 +42,12 @@ public class MenuCategoryController {
   public ResponseEntity<ApiResponse<Void>> deleteMenuCategory(@PathVariable UUID menuCategoryId) {
     menuCategoryService.deleteMenuCategory(menuCategoryId);
     return ResponseEntity.ok(ApiResponse.success(""));
+  }
+
+  @PostMapping("/{menuCategoryId}/menu-items")
+  public ResponseEntity<ApiResponse<MenuItemResponseDto>> createMenuItem(
+      @PathVariable UUID menuCategoryId, @RequestBody MenuItemPostRequestDto request) {
+    MenuItemResponseDto response = menuItemService.createMenuItem(menuCategoryId, request);
+    return ResponseEntity.ok(ApiResponse.success("", response));
   }
 }

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/menu-categories")
+@RequestMapping("/menu-categories")
 @RequiredArgsConstructor
 public class MenuCategoryController {
 

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
@@ -5,16 +5,12 @@ import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
 import com.project.baedalsodae.menu.service.MenuItemService;
+import jakarta.validation.constraints.Positive;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/menu-items")
@@ -34,6 +30,13 @@ public class MenuItemController {
   public ResponseEntity<ApiResponse<MenuItemResponseDto>> patchMenuItem(
       @PathVariable UUID menuItemId, @RequestBody MenuItemPatchRequestDto request) {
     MenuItemResponseDto response = menuItemService.patchMenuItem(menuItemId, request);
+    return ResponseEntity.ok(ApiResponse.success("", response));
+  }
+
+  @PatchMapping("/{menuItemId}/orders")
+  public ResponseEntity<ApiResponse<MenuItemResponseDto>> updateMenuItemOrder(
+      @PathVariable UUID menuItemId, @RequestParam @Validated @Positive Integer order) {
+    MenuItemResponseDto response = menuItemService.updateMenuItemOrder(menuItemId, order);
     return ResponseEntity.ok(ApiResponse.success("", response));
   }
 

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/menu-items")
+@RequestMapping("/menu-items")
 @RequiredArgsConstructor
 public class MenuItemController {
 

--- a/src/main/java/com/project/baedalsodae/menu/dto/requestDto/item/MenuItemPatchRequestDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/requestDto/item/MenuItemPatchRequestDto.java
@@ -1,6 +1,7 @@
 package com.project.baedalsodae.menu.dto.requestDto.item;
 
 import com.project.baedalsodae.menu.entity.enums.MenuStatus;
+import java.util.List;
 import java.util.UUID;
 
 public record MenuItemPatchRequestDto(
@@ -9,4 +10,5 @@ public record MenuItemPatchRequestDto(
     Integer price,
     Boolean isPopular,
     UUID categoryId,
-    MenuStatus menuStatus) {}
+    MenuStatus menuStatus,
+    List<String> tagNames) {}

--- a/src/main/java/com/project/baedalsodae/menu/dto/requestDto/item/MenuItemPostRequestDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/requestDto/item/MenuItemPostRequestDto.java
@@ -1,0 +1,12 @@
+package com.project.baedalsodae.menu.dto.requestDto.item;
+
+import com.project.baedalsodae.menu.entity.enums.MenuStatus;
+import java.util.List;
+
+public record MenuItemPostRequestDto(
+    String name,
+    String description,
+    int price,
+    boolean isPopular,
+    MenuStatus menuStatus,
+    List<String> tagNames) {}

--- a/src/main/java/com/project/baedalsodae/menu/dto/requestDto/item/MenuItemPutRequestDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/requestDto/item/MenuItemPutRequestDto.java
@@ -1,6 +1,7 @@
 package com.project.baedalsodae.menu.dto.requestDto.item;
 
 import com.project.baedalsodae.menu.entity.enums.MenuStatus;
+import java.util.List;
 import java.util.UUID;
 
 public record MenuItemPutRequestDto(
@@ -9,4 +10,5 @@ public record MenuItemPutRequestDto(
     int price,
     boolean isPopular,
     UUID categoryId,
-    MenuStatus menuStatus) {}
+    MenuStatus menuStatus,
+    List<String> tagNames) {}

--- a/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
+++ b/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
@@ -19,10 +19,7 @@ import lombok.NoArgsConstructor;
     uniqueConstraints = {
       @UniqueConstraint(
           name = "uq_menu_item_order_no",
-          columnNames = {"menu_category_id", "order_no"}),
-      @UniqueConstraint(
-          name = "uq_menu_item_name",
-          columnNames = {"menu_category_id", "name"})
+          columnNames = {"menu_category_id", "order_no"})
     })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MenuItem extends BaseAuditEntity implements Orderable {

--- a/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
+++ b/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
@@ -19,7 +19,10 @@ import lombok.NoArgsConstructor;
     uniqueConstraints = {
       @UniqueConstraint(
           name = "uq_menu_item_order_no",
-          columnNames = {"menu_category_id", "order_no"})
+          columnNames = {"menu_category_id", "order_no"}),
+      @UniqueConstraint(
+          name = "uq_menu_item_name",
+          columnNames = {"menu_category_id", "name"})
     })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MenuItem extends BaseAuditEntity implements Orderable {
@@ -54,6 +57,25 @@ public class MenuItem extends BaseAuditEntity implements Orderable {
   @Column(name = "menu_status")
   @Enumerated(EnumType.STRING)
   private MenuStatus menuStatus;
+
+  public static MenuItem createMenuItem(
+      String name,
+      String description,
+      int price,
+      boolean popular,
+      int orderNo,
+      MenuStatus menuStatus,
+      MenuCategory category) {
+    MenuItem menuItem = new MenuItem();
+    menuItem.name = name;
+    menuItem.description = description;
+    menuItem.price = price;
+    menuItem.isPopular = popular;
+    menuItem.menuStatus = menuStatus;
+    menuItem.menuCategory = category;
+    menuItem.orderNo = orderNo;
+    return menuItem;
+  }
 
   public void changeMenuInfo(
       String name,

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
@@ -1,9 +1,12 @@
 package com.project.baedalsodae.menu.repository;
 
 import com.project.baedalsodae.menu.entity.MenuItem;
+import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -18,4 +21,9 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, UUID> {
   Optional<Integer> findMaxOrderNoByMenuCategoryId(UUID menuCategoryId);
 
   boolean existsByMenuCategoryIdAndNameAndIsDeletedIsFalse(UUID menuCategoryId, String name);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      "SELECT i FROM MenuItem i WHERE i.menuCategory.id = :menuCategoryId AND i.isDeleted = false ORDER BY i.orderNo ASC")
+  List<MenuItem> findAllByMenuCategoryIdAndIsDeletedIsFalseForUpdate(UUID menuCategoryId);
 }

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
@@ -14,4 +14,8 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, UUID> {
       "SELECT m FROM MenuItem m join fetch m.menuCategory WHERE m.id = :id AND m.isDeleted ="
           + " false")
   Optional<MenuItem> findByIdAndDeletedIsFalse(UUID id);
+
+  Optional<Integer> findMaxOrderNoByMenuCategoryId(UUID menuCategoryId);
+
+  boolean existsByMenuCategoryIdAndNameAndIsDeletedIsFalse(UUID menuCategoryId, String name);
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
@@ -15,5 +15,8 @@ public interface MenuItemService {
   MenuItemResponseDto patchMenuItem(UUID menuItemId, MenuItemPatchRequestDto request);
 
   void deleteMenuItem(UUID menuItemId);
+
+  boolean isDuplicateMenuItemName(UUID menuCategoryId, String name);
+
   MenuItemResponseDto updateMenuItemOrder(UUID menuItemId, Integer order);
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
@@ -15,4 +15,5 @@ public interface MenuItemService {
   MenuItemResponseDto patchMenuItem(UUID menuItemId, MenuItemPatchRequestDto request);
 
   void deleteMenuItem(UUID menuItemId);
+  MenuItemResponseDto updateMenuItemOrder(UUID menuItemId, Integer order);
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
@@ -1,11 +1,14 @@
 package com.project.baedalsodae.menu.service;
 
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
+import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
 import java.util.UUID;
 
 public interface MenuItemService {
+
+  MenuItemResponseDto createMenuItem(UUID menuCategoryId, MenuItemPostRequestDto request);
 
   MenuItemResponseDto updateMenuItem(UUID menuItemId, MenuItemPutRequestDto request);
 

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -25,6 +25,7 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
   @Transactional
   public MenuCategoryResponseDto updateMenuCategory(
       UUID menuCategoryId, MenuCategoryPutRequestDto request) {
+
     MenuCategory menuCategory =
         menuCategoryRepository
             .findByIdAndDeletedIsFalse(menuCategoryId)
@@ -47,7 +48,6 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
   @Transactional
   public MenuCategoryResponseDto updateMenuCategoryOrder(
       UUID menuCategoryId, MenuCategoryPatchRequestDto request) {
-
     MenuCategory menuCategory =
         menuCategoryRepository
             .findByIdAndDeletedIsFalse(menuCategoryId)

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -40,7 +40,6 @@ public class MenuItemServiceImpl implements MenuItemService {
         request.menuStatus(),
         category,
         request.isPopular());
-    item.changeMenuStatus(request.menuStatus());
     return MenuItemResponseDto.fromEntity(item);
   }
 

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -3,6 +3,7 @@ package com.project.baedalsodae.menu.service.impl;
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
+import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
 import com.project.baedalsodae.menu.entity.MenuCategory;
@@ -10,6 +11,7 @@ import com.project.baedalsodae.menu.entity.MenuItem;
 import com.project.baedalsodae.menu.repository.MenuCategoryRepository;
 import com.project.baedalsodae.menu.repository.MenuItemRepository;
 import com.project.baedalsodae.menu.service.MenuItemService;
+import com.project.baedalsodae.tag.service.TagMappingService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +23,31 @@ public class MenuItemServiceImpl implements MenuItemService {
 
   private final MenuItemRepository menuItemRepository;
   private final MenuCategoryRepository menuCategoryRepository;
+  private final TagMappingService tagMappingService;
+
+  @Transactional
+  @Override
+  public MenuItemResponseDto createMenuItem(UUID menuCategoryId, MenuItemPostRequestDto request) {
+    if (existsByNameAndMenuCategoryIdAndDeletedIsFalse(menuCategoryId, request.name())) {
+      throw new BusinessException(ErrorCode.DUPLICATE_MENU_ITEM_NAME);
+    }
+    MenuCategory category =
+        menuCategoryRepository
+            .findByIdAndDeletedIsFalse(menuCategoryId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+    int maxOrderNo = menuItemRepository.findMaxOrderNoByMenuCategoryId((menuCategoryId)).orElse(0);
+    MenuItem item =
+        MenuItem.createMenuItem(
+            request.name(),
+            request.description(),
+            request.price(),
+            request.isPopular(),
+            maxOrderNo + 1,
+            request.menuStatus(),
+            category);
+    tagMappingService.createTagMappings(menuItemRepository.save(item), request.tagNames());
+    return MenuItemResponseDto.fromEntity(item);
+  }
 
   @Transactional
   @Override
@@ -73,5 +100,9 @@ public class MenuItemServiceImpl implements MenuItemService {
             .findByIdAndDeletedIsFalse(menuItemId)
             .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
     item.softDelete(null); // 토큰 기능 추가 시 수정 필요
+  }
+  private boolean existsByNameAndMenuCategoryIdAndDeletedIsFalse(UUID menuCategoryId, String name) {
+    return menuItemRepository.existsByMenuCategoryIdAndNameAndIsDeletedIsFalse(
+        menuCategoryId, name);
   }
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -30,13 +30,13 @@ public class MenuItemServiceImpl implements MenuItemService {
   @Transactional
   @Override
   public MenuItemResponseDto createMenuItem(UUID menuCategoryId, MenuItemPostRequestDto request) {
-    if (existsByNameAndMenuCategoryIdAndDeletedIsFalse(menuCategoryId, request.name())) {
-      throw new BusinessException(ErrorCode.DUPLICATE_MENU_ITEM_NAME);
-    }
     MenuCategory category =
         menuCategoryRepository
             .findByIdAndDeletedIsFalse(menuCategoryId)
             .orElseThrow(() -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+    if (existsByNameAndMenuCategoryIdAndDeletedIsFalse(menuCategoryId, request.name())) {
+      throw new BusinessException(ErrorCode.DUPLICATE_MENU_ITEM_NAME);
+    }
     int maxOrderNo = menuItemRepository.findMaxOrderNoByMenuCategoryId((menuCategoryId)).orElse(0);
     MenuItem item =
         MenuItem.createMenuItem(

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -13,11 +13,13 @@ import com.project.baedalsodae.menu.repository.MenuCategoryRepository;
 import com.project.baedalsodae.menu.repository.MenuItemRepository;
 import com.project.baedalsodae.menu.service.MenuItemService;
 import com.project.baedalsodae.tag.service.TagMappingService;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -47,7 +49,11 @@ public class MenuItemServiceImpl implements MenuItemService {
             maxOrderNo + 1,
             request.menuStatus(),
             category);
-    tagMappingService.createTagMappings(menuItemRepository.save(item), request.tagNames());
+    try {
+      tagMappingService.createTagMappings(menuItemRepository.save(item), request.tagNames());
+    } catch (DataIntegrityViolationException e) {
+      throw new BusinessException(ErrorCode.MENU_ITEM_ORDER_CONFLICT);
+    }
     return MenuItemResponseDto.fromEntity(item);
   }
 

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -67,6 +67,8 @@ public class MenuItemServiceImpl implements MenuItemService {
         request.menuStatus(),
         category,
         request.isPopular());
+    tagMappingService.deleteAllTagMappingByMenuItemId(menuItemId);
+    tagMappingService.createTagMappings(item, request.tagNames());
     return MenuItemResponseDto.fromEntity(item);
   }
 
@@ -89,6 +91,10 @@ public class MenuItemServiceImpl implements MenuItemService {
     if (request.price() != null) item.changePrice(request.price());
     if (request.isPopular() != null) item.changeIsPopular(request.isPopular());
     if (request.menuStatus() != null) item.changeMenuStatus(request.menuStatus());
+    if (request.tagNames() != null) {
+      tagMappingService.deleteAllTagMappingByMenuItemId(menuItemId);
+      tagMappingService.createTagMappings(item, request.tagNames());
+    }
     return MenuItemResponseDto.fromEntity(item);
   }
 

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -110,6 +110,10 @@ public class MenuItemServiceImpl implements MenuItemService {
     item.softDelete(null); // 토큰 기능 추가 시 수정 필요
   }
 
+  @Override
+  public boolean isDuplicateMenuItemName(UUID menuCategoryId, String name) {
+    return existsByNameAndMenuCategoryIdAndDeletedIsFalse(menuCategoryId, name);
+  }
 
   @Transactional
   @Override

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -2,6 +2,7 @@ package com.project.baedalsodae.menu.service.impl;
 
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
+import com.project.baedalsodae.menu.common.OrderUtil;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
@@ -12,6 +13,7 @@ import com.project.baedalsodae.menu.repository.MenuCategoryRepository;
 import com.project.baedalsodae.menu.repository.MenuItemRepository;
 import com.project.baedalsodae.menu.service.MenuItemService;
 import com.project.baedalsodae.tag.service.TagMappingService;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -107,6 +109,34 @@ public class MenuItemServiceImpl implements MenuItemService {
             .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
     item.softDelete(null); // 토큰 기능 추가 시 수정 필요
   }
+
+
+  @Transactional
+  @Override
+  public MenuItemResponseDto updateMenuItemOrder(UUID menuItemId, Integer order) {
+    MenuItem item =
+        menuItemRepository
+            .findByIdAndDeletedIsFalse(menuItemId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
+    Integer from = item.getOrderNo();
+    if (from == null) {
+      throw new BusinessException(ErrorCode.INVALID_MENU_ITEM_ORDER);
+    }
+    int to = order;
+
+    if (from == to) {
+      return MenuItemResponseDto.fromEntity(item);
+    }
+
+    UUID menuCategoryId = item.getMenuCategory().getId();
+
+    List<MenuItem> menuItems =
+        menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalseForUpdate(menuCategoryId);
+
+    OrderUtil.reorder(menuItems, item, from, to);
+    return MenuItemResponseDto.fromEntity(item);
+  }
+
   private boolean existsByNameAndMenuCategoryIdAndDeletedIsFalse(UUID menuCategoryId, String name) {
     return menuItemRepository.existsByMenuCategoryIdAndNameAndIsDeletedIsFalse(
         menuCategoryId, name);


### PR DESCRIPTION
### 📌 관련 이슈
- close #47

### 💡 작업 내용
- MenuItem 생성 기능 구현
- MenuItem 순서 변경 기능 구현
- 수정 관련 로직시 태그 변경 기능 추가 
- MenuItem 생성 시 이름 중복 체크 기능 추가  

### 🔍 변경 이유
 - MenuItem CRUD 중 생성/수정 기능 미구현 상태였으며, 순서 변경 및 태그 연동 기능이 필요해 작업

### 📝 리뷰 포인트 (선택)
  - updateMenuItemOrder에서 PESSIMISTIC_WRITE 락 적용 범위가 적절한지
  - createMenuItem 시 중복 체크 → 카테고리 조회 순서가 적절한지

### 🧠 기타 참고 사항
 - updateMenuCategory 이름 중복 체크 누락은 category 관련 브랜치에서 처리 예정
  - 삭제 시 orderNo gap 문제는 순서 관련 브랜치에서 별도 처리 예정