### PR TITLE
Feat/56 menucategory create

### DIFF
--- a/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
+++ b/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     MENU_CATEGORY_NOT_FOUND("MC001", HttpStatus.NOT_FOUND, "메뉴 카테고리가 없습니다"),
     INVALID_MENU_CATEGORY_ORDER("MC002", HttpStatus.BAD_REQUEST, "메뉴 카테고리 순서가 잘못됐습니다."),
     DUPLICATE_MENU_CATEGORY_NAME("MC003", HttpStatus.CONFLICT, "같은 가게에 같은 이름의 메뉴 카테고리가 존재합니다"),
+    MENU_CATEGORY_ORDER_CONFLICT("MC004", HttpStatus.CONFLICT, "메뉴 카테고리 순서가 충돌했습니다. 다시 시도해주세요."),
 
     // menuItem
     MENU_ITEM_NOT_FOUND("MI001", HttpStatus.NOT_FOUND, "메뉴 아이템이 없습니다"),

--- a/src/main/java/com/project/baedalsodae/global/common/SuccessCode.java
+++ b/src/main/java/com/project/baedalsodae/global/common/SuccessCode.java
@@ -31,6 +31,9 @@ public enum SuccessCode {
     STORE_STATUS_UPDATED("ST200", HttpStatus.OK, "가게 영업 상태 변경 성공"),
     STORE_DELETED("ST200", HttpStatus.OK, "가게 삭제 성공"),
 
+    // menu category
+    MENU_CATEGORY_CREATED("MC201", HttpStatus.CREATED, "메뉴 카테고리 생성 성공"),
+
     // payment
     PAYMENT_HISTORY_FOUND("PY200", HttpStatus.OK, "결제 내역 조회 성공"),
     PAYMENT_DETAIL_FOUND("PY201", HttpStatus.OK, "결제 상세 조회 성공");

--- a/src/main/java/com/project/baedalsodae/global/common/SuccessCode.java
+++ b/src/main/java/com/project/baedalsodae/global/common/SuccessCode.java
@@ -33,6 +33,9 @@ public enum SuccessCode {
 
     // menu category
     MENU_CATEGORY_CREATED("MC201", HttpStatus.CREATED, "메뉴 카테고리 생성 성공"),
+    MENU_CATEGORY_UPDATED("MC202", HttpStatus.OK, "메뉴 카테고리 수정 성공"),
+    MENU_CATEGORY_DELETED("MC203", HttpStatus.OK, "메뉴 카테고리 삭제 성공"),
+    MENU_CATEGORY_LIST_FOUND("MC204", HttpStatus.OK, "메뉴 카테고리 목록 조회 성공"),
 
     // payment
     PAYMENT_HISTORY_FOUND("PY200", HttpStatus.OK, "결제 내역 조회 성공"),

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -9,6 +9,8 @@ import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
 import com.project.baedalsodae.menu.service.MenuCategoryService;
 import com.project.baedalsodae.menu.service.MenuItemService;
 import jakarta.validation.Valid;
+
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -43,6 +45,14 @@ public class MenuCategoryController {
     public ResponseEntity<ApiResponse<Void>> deleteMenuCategory(@PathVariable UUID menuCategoryId) {
         menuCategoryService.deleteMenuCategory(menuCategoryId);
         return ResponseEntity.ok(ApiResponse.success(""));
+    }
+
+
+    @GetMapping("/{menuCategoryId}/menu-items")
+    public ResponseEntity<ApiResponse<List<MenuItemResponseDto>>> getMenuItem(
+            @PathVariable UUID menuCategoryId) {
+        List<MenuItemResponseDto> response = menuItemService.getMenuItem(menuCategoryId);
+        return ResponseEntity.ok(ApiResponse.success("", response));
     }
 
     @PostMapping("/{menuCategoryId}/menu-items")

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -9,7 +9,6 @@ import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
 import com.project.baedalsodae.menu.service.MenuCategoryService;
 import com.project.baedalsodae.menu.service.MenuItemService;
 import jakarta.validation.Valid;
-
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +45,6 @@ public class MenuCategoryController {
         menuCategoryService.deleteMenuCategory(menuCategoryId);
         return ResponseEntity.ok(ApiResponse.success(""));
     }
-
 
     @GetMapping("/{menuCategoryId}/menu-items")
     public ResponseEntity<ApiResponse<List<MenuItemResponseDto>>> getMenuItem(

--- a/src/main/java/com/project/baedalsodae/menu/dto/requestDto/category/MenuCategoryPostRequestDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/requestDto/category/MenuCategoryPostRequestDto.java
@@ -1,0 +1,5 @@
+package com.project.baedalsodae.menu.dto.requestDto.category;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MenuCategoryPostRequestDto(@NotBlank String name) {}

--- a/src/main/java/com/project/baedalsodae/menu/dto/responseDto/category/MenuCategoryResponseDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/responseDto/category/MenuCategoryResponseDto.java
@@ -1,11 +1,16 @@
 package com.project.baedalsodae.menu.dto.responseDto.category;
 
 import com.project.baedalsodae.menu.entity.MenuCategory;
+import java.util.List;
 import java.util.UUID;
 
 public record MenuCategoryResponseDto(UUID id, String name, int orderNo) {
     public static MenuCategoryResponseDto fromEntity(MenuCategory category) {
         return new MenuCategoryResponseDto(
                 category.getId(), category.getName(), category.getOrderNo());
+    }
+
+    public static List<MenuCategoryResponseDto> fromEntityList(List<MenuCategory> menuCategories) {
+        return menuCategories.stream().map(MenuCategoryResponseDto::fromEntity).toList();
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/entity/MenuCategory.java
+++ b/src/main/java/com/project/baedalsodae/menu/entity/MenuCategory.java
@@ -41,6 +41,16 @@ public class MenuCategory extends BaseAuditEntity implements Orderable {
     @ManyToOne(fetch = FetchType.LAZY)
     private Store store;
 
+    private MenuCategory(Store store, String name, int orderNo) {
+        this.store = store;
+        this.name = name;
+        this.orderNo = orderNo;
+    }
+
+    public static MenuCategory create(Store store, String name, int orderNo) {
+        return new MenuCategory(store, name, orderNo);
+    }
+
     public void changeMenuCategoryName(String name) {
         this.name = name;
     }

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
@@ -27,4 +27,6 @@ public interface MenuCategoryRepository extends JpaRepository<MenuCategory, UUID
             "SELECT MAX(c.orderNo) FROM MenuCategory c WHERE c.store.id = :storeId "
                     + "AND c.isDeleted = false")
     Optional<Integer> findMaxOrderNoByStoreIdAndDeletedIsFalse(UUID storeId);
+
+    List<MenuCategory> findAllByStoreIdAndDeletedIsFalse(UUID storeId);
 }

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
@@ -21,5 +21,5 @@ public interface MenuCategoryRepository extends JpaRepository<MenuCategory, UUID
     @Query(
             "SELECT c FROM MenuCategory c WHERE c.store.id = :storeId AND c.isDeleted = false ORDER "
                     + "BY c.orderNo ASC")
-    List<MenuCategory> findAllByStoreIdAndDeletedIsFalseForUpdate(UUID storeId);
+    List<MenuCategory> findAllByStoreIdAndDeletedIsFalseWithLock(UUID storeId);
 }

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
@@ -28,5 +28,8 @@ public interface MenuCategoryRepository extends JpaRepository<MenuCategory, UUID
                     + "AND c.isDeleted = false")
     Optional<Integer> findMaxOrderNoByStoreIdAndDeletedIsFalse(UUID storeId);
 
+    @Query(
+            "SELECT c FROM MenuCategory c WHERE c.store.id = :storeId AND c.isDeleted = false ORDER "
+                    + "BY c.orderNo ASC")
     List<MenuCategory> findAllByStoreIdAndDeletedIsFalse(UUID storeId);
 }

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
@@ -22,4 +22,9 @@ public interface MenuCategoryRepository extends JpaRepository<MenuCategory, UUID
             "SELECT c FROM MenuCategory c WHERE c.store.id = :storeId AND c.isDeleted = false ORDER "
                     + "BY c.orderNo ASC")
     List<MenuCategory> findAllByStoreIdAndDeletedIsFalseWithLock(UUID storeId);
+
+    @Query(
+            "SELECT MAX(c.orderNo) FROM MenuCategory c WHERE c.store.id = :storeId "
+                    + "AND c.isDeleted = false")
+    Optional<Integer> findMaxOrderNoByStoreIdAndDeletedIsFalse(UUID storeId);
 }

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
@@ -25,5 +25,5 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, UUID> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(
             "SELECT i FROM MenuItem i WHERE i.menuCategory.id = :menuCategoryId AND i.isDeleted = false ORDER BY i.orderNo ASC")
-    List<MenuItem> findAllByMenuCategoryIdAndIsDeletedIsFalseForUpdate(UUID menuCategoryId);
+    List<MenuItem> findAllByMenuCategoryIdAndIsDeletedIsFalseWithLock(UUID menuCategoryId);
 }

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
@@ -18,6 +18,9 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, UUID> {
                     + " false")
     Optional<MenuItem> findByIdAndDeletedIsFalse(UUID id);
 
+    @Query(
+            "SELECT MAX(i.orderNo) FROM MenuItem i WHERE i.menuCategory.id = :menuCategoryId "
+                    + "AND i.isDeleted = false")
     Optional<Integer> findMaxOrderNoByMenuCategoryId(UUID menuCategoryId);
 
     boolean existsByMenuCategoryIdAndNameAndIsDeletedIsFalse(UUID menuCategoryId, String name);

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
@@ -29,4 +29,8 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, UUID> {
     @Query(
             "SELECT i FROM MenuItem i WHERE i.menuCategory.id = :menuCategoryId AND i.isDeleted = false ORDER BY i.orderNo ASC")
     List<MenuItem> findAllByMenuCategoryIdAndIsDeletedIsFalseWithLock(UUID menuCategoryId);
+
+    @Query(
+            "SELECT i FROM MenuItem i WHERE i.menuCategory.id = :menuCategoryId AND i.isDeleted = false ORDER BY i.orderNo ASC")
+    List<MenuItem> findAllByMenuCategoryIdAndIsDeletedIsFalse(UUID menuCategoryId);
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuCategoryService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuCategoryService.java
@@ -4,6 +4,7 @@ import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchReq
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
+import java.util.List;
 import java.util.UUID;
 
 public interface MenuCategoryService {
@@ -17,4 +18,6 @@ public interface MenuCategoryService {
 
     MenuCategoryResponseDto updateMenuCategoryOrder(
             UUID menuCategoryId, MenuCategoryPatchRequestDto request);
+
+    List<MenuCategoryResponseDto> getMenuCategories(UUID storeId);
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuCategoryService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuCategoryService.java
@@ -1,11 +1,14 @@
 package com.project.baedalsodae.menu.service;
 
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
 import java.util.UUID;
 
 public interface MenuCategoryService {
+
+    MenuCategoryResponseDto createMenuCategory(UUID storeId, MenuCategoryPostRequestDto request);
 
     MenuCategoryResponseDto updateMenuCategory(
             UUID menuCategoryId, MenuCategoryPutRequestDto request);

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
@@ -4,6 +4,9 @@ import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 import java.util.UUID;
 
 public interface MenuItemService {
@@ -19,4 +22,6 @@ public interface MenuItemService {
     boolean isDuplicateMenuItemName(UUID menuCategoryId, String name);
 
     MenuItemResponseDto updateMenuItemOrder(UUID menuItemId, Integer order);
+
+    List<MenuItemResponseDto> getMenuItem(UUID menuCategoryId);
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
@@ -4,8 +4,6 @@ import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -15,6 +15,7 @@ import com.project.baedalsodae.store.repository.StoreRepository;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +39,11 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
                         .findMaxOrderNoByStoreIdAndDeletedIsFalse((storeId))
                         .orElse(0);
         MenuCategory menuCategory = MenuCategory.create(store, request.name(), maxOrderNo + 1);
-        menuCategoryRepository.save(menuCategory);
+        try {
+            menuCategoryRepository.save(menuCategory);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.MENU_CATEGORY_ORDER_CONFLICT);
+        }
         return MenuCategoryResponseDto.fromEntity(menuCategory);
     }
 

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -25,7 +25,6 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
     @Transactional
     public MenuCategoryResponseDto updateMenuCategory(
             UUID menuCategoryId, MenuCategoryPutRequestDto request) {
-
         MenuCategory menuCategory =
                 menuCategoryRepository
                         .findByIdAndDeletedIsFalse(menuCategoryId)
@@ -68,7 +67,7 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
         UUID storeId = menuCategory.getStore().getId();
 
         List<MenuCategory> menuCategories =
-                menuCategoryRepository.findAllByStoreIdAndDeletedIsFalseForUpdate(storeId);
+                menuCategoryRepository.findAllByStoreIdAndDeletedIsFalseWithLock(storeId);
 
         OrderUtil.reorder(menuCategories, menuCategory, from, to);
         return MenuCategoryResponseDto.fromEntity(menuCategory);

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -32,7 +32,7 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
             UUID storeId, MenuCategoryPostRequestDto request) {
         Store store =
                 storeRepository
-                        .findByIdAndDeletedIsFalse(storeId)
+                        .findByIdAndIsDeletedIsFalse(storeId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
         int maxOrderNo =
                 menuCategoryRepository

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -93,4 +93,12 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
         OrderUtil.reorder(menuCategories, menuCategory, from, to);
         return MenuCategoryResponseDto.fromEntity(menuCategory);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MenuCategoryResponseDto> getMenuCategories(UUID storeId) {
+        List<MenuCategory> menuCategories =
+                menuCategoryRepository.findAllByStoreIdAndDeletedIsFalse(storeId);
+        return MenuCategoryResponseDto.fromEntityList(menuCategories);
+    }
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -4,11 +4,14 @@ import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
 import com.project.baedalsodae.menu.common.OrderUtil;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
 import com.project.baedalsodae.menu.entity.MenuCategory;
 import com.project.baedalsodae.menu.repository.MenuCategoryRepository;
 import com.project.baedalsodae.menu.service.MenuCategoryService;
+import com.project.baedalsodae.store.entity.Store;
+import com.project.baedalsodae.store.repository.StoreRepository;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class MenuCategoryServiceImpl implements MenuCategoryService {
 
     private final MenuCategoryRepository menuCategoryRepository;
+    private final StoreRepository storeRepository;
+
+    @Override
+    @Transactional
+    public MenuCategoryResponseDto createMenuCategory(
+            UUID storeId, MenuCategoryPostRequestDto request) {
+        Store store =
+                storeRepository
+                        .findByIdAndDeletedIsFalse(storeId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+        int maxOrderNo =
+                menuCategoryRepository
+                        .findMaxOrderNoByStoreIdAndDeletedIsFalse((storeId))
+                        .orElse(0);
+        MenuCategory menuCategory = MenuCategory.create(store, request.name(), maxOrderNo + 1);
+        menuCategoryRepository.save(menuCategory);
+        return MenuCategoryResponseDto.fromEntity(menuCategory);
+    }
 
     @Override
     @Transactional

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -151,6 +151,15 @@ public class MenuItemServiceImpl implements MenuItemService {
         return MenuItemResponseDto.fromEntity(item);
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public List<MenuItemResponseDto> getMenuItem(UUID menuCategoryId) {
+        List<MenuItem> menuItems =
+                menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalse(menuCategoryId);
+
+        return menuItems.stream().map(MenuItemResponseDto::fromEntity).toList();
+    }
+
     private boolean existsByNameAndMenuCategoryIdAndDeletedIsFalse(
             UUID menuCategoryId, String name) {
         return menuItemRepository.existsByMenuCategoryIdAndNameAndIsDeletedIsFalse(

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -144,7 +144,7 @@ public class MenuItemServiceImpl implements MenuItemService {
         UUID menuCategoryId = item.getMenuCategory().getId();
 
         List<MenuItem> menuItems =
-                menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalseForUpdate(
+                menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalseWithLock(
                         menuCategoryId);
 
         OrderUtil.reorder(menuItems, item, from, to);

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -151,8 +151,8 @@ public class MenuItemServiceImpl implements MenuItemService {
         return MenuItemResponseDto.fromEntity(item);
     }
 
-    @Transactional(readOnly = true)
     @Override
+    @Transactional(readOnly = true)
     public List<MenuItemResponseDto> getMenuItem(UUID menuCategoryId) {
         List<MenuItem> menuItems =
                 menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalse(menuCategoryId);

--- a/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
+++ b/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
@@ -10,6 +10,7 @@ import com.project.baedalsodae.store.dto.request.UpdateStoreRequest;
 import com.project.baedalsodae.store.dto.request.UpdateStoreStatusRequest;
 import com.project.baedalsodae.store.service.StoreCommandService;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -61,5 +62,13 @@ public class StoreController {
             @PathVariable UUID storeId, @RequestBody @Valid MenuCategoryPostRequestDto request) {
         MenuCategoryResponseDto response = menuCategoryService.createMenuCategory(storeId, request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_CREATED, response));
+    }
+
+    @GetMapping("/{storeId}/menu-categories")
+    public ResponseEntity<ApiResponse<List<MenuCategoryResponseDto>>> getMenuCategories(
+            @PathVariable UUID storeId) {
+        List<MenuCategoryResponseDto> response = menuCategoryService.getMenuCategories(storeId);
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.MENU_CATEGORY_LIST_FOUND, response));
     }
 }

--- a/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
+++ b/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
@@ -2,6 +2,9 @@ package com.project.baedalsodae.store.controller;
 
 import com.project.baedalsodae.global.common.ApiResponse;
 import com.project.baedalsodae.global.common.SuccessCode;
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
+import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
+import com.project.baedalsodae.menu.service.MenuCategoryService;
 import com.project.baedalsodae.store.dto.request.CreateStoreRequest;
 import com.project.baedalsodae.store.dto.request.UpdateStoreRequest;
 import com.project.baedalsodae.store.dto.request.UpdateStoreStatusRequest;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/stores")
 public class StoreController {
     private final StoreCommandService storeCommandService;
+    private final MenuCategoryService menuCategoryService;
 
     // TODO 인증 도메인 완료되면, userId 추가
     @PostMapping
@@ -50,5 +54,12 @@ public class StoreController {
             @RequestHeader("X-User-Id") UUID userId, @PathVariable UUID storeId) {
         storeCommandService.deleteStore(storeId, userId);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.STORE_DELETED, null));
+    }
+
+    @PostMapping("/{storeId}/menu-categories")
+    public ResponseEntity<ApiResponse<MenuCategoryResponseDto>> createMenuCategory(
+            @PathVariable UUID storeId, @RequestBody @Valid MenuCategoryPostRequestDto request) {
+        MenuCategoryResponseDto response = menuCategoryService.createMenuCategory(storeId, request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_CREATED, response));
     }
 }

--- a/src/main/java/com/project/baedalsodae/store/repository/StoreRepository.java
+++ b/src/main/java/com/project/baedalsodae/store/repository/StoreRepository.java
@@ -1,6 +1,7 @@
 package com.project.baedalsodae.store.repository;
 
 import com.project.baedalsodae.store.entity.Store;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StoreRepository extends JpaRepository<Store, UUID> {
     Boolean existsByBusinessNumber(String businessNumber);
+
+    Optional<Store> findByIdAndDeletedIsFalse(UUID id);
 }

--- a/src/main/java/com/project/baedalsodae/store/repository/StoreRepository.java
+++ b/src/main/java/com/project/baedalsodae/store/repository/StoreRepository.java
@@ -10,5 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface StoreRepository extends JpaRepository<Store, UUID> {
     Boolean existsByBusinessNumber(String businessNumber);
 
-    Optional<Store> findByIdAndDeletedIsFalse(UUID id);
+    Optional<Store> findByIdAndIsDeletedIsFalse(UUID id);
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #56

### 💡 작업 내용
- 메뉴 카테고리 생성 기능 구현 
- 메뉴 카테고리 내 아이템 반환 기능 추가 
- 메뉴 카테고리등 반환 기능 추가 
- 그외 버그 및 네이밍 컨벤션에 벗어나는 부분 수정 

### 🔍 변경 이유
  - 가게 운영자가 메뉴 카테고리를 생성·조회할 수 있도록 기능 추가
  - 카테고리 생성 시 기존 최대 순서 번호 + 1로 자동 부여하여 순서 관리 일관성 유지
  - 메뉴 아이템 조회는 orderNo 기준 정렬된 리스트를 반환하기 위해 별도 쿼리 메서드 추가
  - `ForUpdate` 메서드명이 비관적 락 사용 여부를 불명확하게 표현하고 있어 `WithLock`으로 통일

### 📝 리뷰 포인트 (선택)
- 

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)