### PR TITLE
Fix/65 menu category item common logic

### DIFF
--- a/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
+++ b/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
@@ -42,6 +42,8 @@ public enum ErrorCode {
     INVALID_MENU_CATEGORY_ORDER("MC002", HttpStatus.BAD_REQUEST, "메뉴 카테고리 순서가 잘못됐습니다."),
     DUPLICATE_MENU_CATEGORY_NAME("MC003", HttpStatus.CONFLICT, "같은 가게에 같은 이름의 메뉴 카테고리가 존재합니다"),
     MENU_CATEGORY_ORDER_CONFLICT("MC004", HttpStatus.CONFLICT, "메뉴 카테고리 순서가 충돌했습니다. 다시 시도해주세요."),
+    MENU_CATEGORY_HAS_ITEMS(
+            "MC005", HttpStatus.BAD_REQUEST, "메뉴 카테고리에 메뉴 아이템이 존재합니다. 먼저 메뉴 아이템을 삭제해주세요."),
 
     // menuItem
     MENU_ITEM_NOT_FOUND("MI001", HttpStatus.NOT_FOUND, "메뉴 아이템이 없습니다"),

--- a/src/main/java/com/project/baedalsodae/global/common/SuccessCode.java
+++ b/src/main/java/com/project/baedalsodae/global/common/SuccessCode.java
@@ -32,10 +32,20 @@ public enum SuccessCode {
     STORE_DELETED("ST200", HttpStatus.OK, "가게 삭제 성공"),
 
     // menu category
-    MENU_CATEGORY_CREATED("MC201", HttpStatus.CREATED, "메뉴 카테고리 생성 성공"),
-    MENU_CATEGORY_UPDATED("MC202", HttpStatus.OK, "메뉴 카테고리 수정 성공"),
-    MENU_CATEGORY_DELETED("MC203", HttpStatus.OK, "메뉴 카테고리 삭제 성공"),
-    MENU_CATEGORY_LIST_FOUND("MC204", HttpStatus.OK, "메뉴 카테고리 목록 조회 성공"),
+    MENU_CATEGORY_CREATED("MC200", HttpStatus.CREATED, "메뉴 카테고리 등록 성공"),
+    MENU_CATEGORY_UPDATED("MC201", HttpStatus.OK, "메뉴 카테고리 수정 성공"),
+    MENU_CATEGORY_DELETED("MC202", HttpStatus.OK, "메뉴 카테고리 삭제 성공"),
+    MENU_CATEGORY_ORDER_UPDATED("MC203", HttpStatus.OK, "메뉴 카테고리 순서 변경 성공"),
+    MENU_CATEGORY_NAME_DUPLICATE_CHECKED("MC204", HttpStatus.OK, "메뉴 카테고리 이름 중복 체크 성공"),
+    MENU_CATEGORY_LIST_FOUND("MC205", HttpStatus.OK, "메뉴 카테고리 목록 조회 성공"),
+
+    // menu item
+    MENU_ITEM_CREATED("MI200", HttpStatus.CREATED, "메뉴 아이템 등록 성공"),
+    MENU_ITEM_UPDATED("MI201", HttpStatus.OK, "메뉴 아이템 수정 성공"),
+    MENU_ITEM_DELETED("MI202", HttpStatus.OK, "메뉴 아이템 삭제 성공"),
+    MENU_ITEM_ORDER_UPDATED("MI203", HttpStatus.OK, "메뉴 아이템 순서 변경 성공"),
+    MENU_ITEM_NAME_DUPLICATE_CHECKED("MI204", HttpStatus.OK, "메뉴 아이템 이름 중복 체크 성공"),
+    MENU_ITEM_LIST_FOUND("MI205", HttpStatus.OK, "메뉴 아이템 목록 조회 성공"),
 
     // payment
     PAYMENT_HISTORY_FOUND("PY200", HttpStatus.OK, "결제 내역 조회 성공"),

--- a/src/main/java/com/project/baedalsodae/global/component/DatabaseIndexInitializer.java
+++ b/src/main/java/com/project/baedalsodae/global/component/DatabaseIndexInitializer.java
@@ -1,0 +1,24 @@
+package com.project.baedalsodae.global.component;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DatabaseIndexInitializer implements ApplicationRunner {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  @Override
+  public void run(ApplicationArguments args) {
+    jdbcTemplate.execute(
+        """
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_menu_category_name_active
+      ON baedalsodae.p_menu_category (store_id, name)
+      WHERE is_deleted = false
+      """);
+  }
+}

--- a/src/main/java/com/project/baedalsodae/global/component/DatabaseIndexInitializer.java
+++ b/src/main/java/com/project/baedalsodae/global/component/DatabaseIndexInitializer.java
@@ -10,15 +10,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DatabaseIndexInitializer implements ApplicationRunner {
 
-  private final JdbcTemplate jdbcTemplate;
+    private final JdbcTemplate jdbcTemplate;
 
-  @Override
-  public void run(ApplicationArguments args) {
-    jdbcTemplate.execute(
-        """
+    @Override
+    public void run(ApplicationArguments args) {
+        jdbcTemplate.execute(
+                """
       CREATE UNIQUE INDEX IF NOT EXISTS uq_menu_category_name_active
       ON baedalsodae.p_menu_category (store_id, name)
       WHERE is_deleted = false
       """);
-  }
+    }
 }

--- a/src/main/java/com/project/baedalsodae/menu/common/OrderUtil.java
+++ b/src/main/java/com/project/baedalsodae/menu/common/OrderUtil.java
@@ -28,4 +28,12 @@ public class OrderUtil {
         shiftBetween(items, from, to);
         target.changeOrderNo(to);
     }
+
+    public static <T extends Orderable> void deleteAndShift(List<T> items, T target) {
+        int deletedOrderNo = target.getOrderNo();
+        target.changeOrderNo(null);
+        items.stream()
+                .filter(item -> item.getOrderNo() != null && item.getOrderNo() > deletedOrderNo)
+                .forEach(item -> item.changeOrderNo(item.getOrderNo() - 1));
+    }
 }

--- a/src/main/java/com/project/baedalsodae/menu/common/Orderable.java
+++ b/src/main/java/com/project/baedalsodae/menu/common/Orderable.java
@@ -4,5 +4,5 @@ public interface Orderable {
 
     Integer getOrderNo();
 
-    void changeOrderNo(int order);
+    void changeOrderNo(Integer order);
 }

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -26,7 +26,8 @@ public class MenuCategoryController {
 
     @PutMapping("/{menuCategoryId}")
     public ResponseEntity<ApiResponse<MenuCategoryResponseDto>> updateMenuCategory(
-            @PathVariable UUID menuCategoryId, @Valid @RequestBody MenuCategoryPutRequestDto request) {
+            @PathVariable UUID menuCategoryId,
+            @Valid @RequestBody MenuCategoryPutRequestDto request) {
         MenuCategoryResponseDto response =
                 menuCategoryService.updateMenuCategory(menuCategoryId, request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_UPDATED, response));

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -61,12 +61,4 @@ public class MenuCategoryController {
         MenuItemResponseDto response = menuItemService.createMenuItem(menuCategoryId, request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_CREATED, response));
     }
-
-    @GetMapping("/{menuCategoryId}/menu-items/duplicate-check")
-    public ResponseEntity<ApiResponse<Boolean>> checkDuplicateMenuItemName(
-            @PathVariable UUID menuCategoryId, @RequestParam String name) {
-        boolean isDuplicate = menuItemService.isDuplicateMenuItemName(menuCategoryId, name);
-        return ResponseEntity.ok(
-                ApiResponse.success(SuccessCode.MENU_ITEM_NAME_DUPLICATE_CHECKED, isDuplicate));
-    }
 }

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -26,7 +26,7 @@ public class MenuCategoryController {
 
     @PutMapping("/{menuCategoryId}")
     public ResponseEntity<ApiResponse<MenuCategoryResponseDto>> updateMenuCategory(
-            @PathVariable UUID menuCategoryId, @RequestBody MenuCategoryPutRequestDto request) {
+            @PathVariable UUID menuCategoryId, @Valid @RequestBody MenuCategoryPutRequestDto request) {
         MenuCategoryResponseDto response =
                 menuCategoryService.updateMenuCategory(menuCategoryId, request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_UPDATED, response));
@@ -57,7 +57,7 @@ public class MenuCategoryController {
 
     @PostMapping("/{menuCategoryId}/menu-items")
     public ResponseEntity<ApiResponse<MenuItemResponseDto>> createMenuItem(
-            @PathVariable UUID menuCategoryId, @RequestBody MenuItemPostRequestDto request) {
+            @PathVariable UUID menuCategoryId, @Valid @RequestBody MenuItemPostRequestDto request) {
         MenuItemResponseDto response = menuItemService.createMenuItem(menuCategoryId, request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_CREATED, response));
     }

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -1,6 +1,7 @@
 package com.project.baedalsodae.menu.controller;
 
 import com.project.baedalsodae.global.common.ApiResponse;
+import com.project.baedalsodae.global.common.SuccessCode;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPostRequestDto;
@@ -28,7 +29,7 @@ public class MenuCategoryController {
             @PathVariable UUID menuCategoryId, @RequestBody MenuCategoryPutRequestDto request) {
         MenuCategoryResponseDto response =
                 menuCategoryService.updateMenuCategory(menuCategoryId, request);
-        return ResponseEntity.ok(ApiResponse.success("", response));
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_UPDATED, response));
     }
 
     @PatchMapping("/{menuCategoryId}/orders")
@@ -37,33 +38,35 @@ public class MenuCategoryController {
             @Valid @RequestBody MenuCategoryPatchRequestDto request) {
         MenuCategoryResponseDto response =
                 menuCategoryService.updateMenuCategoryOrder(menuCategoryId, request);
-        return ResponseEntity.ok(ApiResponse.success("", response));
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.MENU_CATEGORY_ORDER_UPDATED, response));
     }
 
     @DeleteMapping("/{menuCategoryId}")
     public ResponseEntity<ApiResponse<Void>> deleteMenuCategory(@PathVariable UUID menuCategoryId) {
         menuCategoryService.deleteMenuCategory(menuCategoryId);
-        return ResponseEntity.ok(ApiResponse.success(""));
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_DELETED, null));
     }
 
     @GetMapping("/{menuCategoryId}/menu-items")
     public ResponseEntity<ApiResponse<List<MenuItemResponseDto>>> getMenuItem(
             @PathVariable UUID menuCategoryId) {
         List<MenuItemResponseDto> response = menuItemService.getMenuItem(menuCategoryId);
-        return ResponseEntity.ok(ApiResponse.success("", response));
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_LIST_FOUND, response));
     }
 
     @PostMapping("/{menuCategoryId}/menu-items")
     public ResponseEntity<ApiResponse<MenuItemResponseDto>> createMenuItem(
             @PathVariable UUID menuCategoryId, @RequestBody MenuItemPostRequestDto request) {
         MenuItemResponseDto response = menuItemService.createMenuItem(menuCategoryId, request);
-        return ResponseEntity.ok(ApiResponse.success("", response));
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_CREATED, response));
     }
 
     @GetMapping("/{menuCategoryId}/menu-items/duplicate-check")
     public ResponseEntity<ApiResponse<Boolean>> checkDuplicateMenuItemName(
             @PathVariable UUID menuCategoryId, @RequestParam String name) {
         boolean isDuplicate = menuItemService.isDuplicateMenuItemName(menuCategoryId, name);
-        return ResponseEntity.ok(ApiResponse.success("", isDuplicate));
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.MENU_ITEM_NAME_DUPLICATE_CHECKED, isDuplicate));
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
@@ -6,6 +6,7 @@ import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
 import com.project.baedalsodae.menu.service.MenuItemService;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class MenuItemController {
 
     @PutMapping("/{menuItemId}")
     public ResponseEntity<ApiResponse<MenuItemResponseDto>> updateMenuItem(
-            @PathVariable UUID menuItemId, @RequestBody MenuItemPutRequestDto request) {
+            @PathVariable UUID menuItemId, @Valid @RequestBody MenuItemPutRequestDto request) {
         MenuItemResponseDto response = menuItemService.updateMenuItem(menuItemId, request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_UPDATED, response));
     }

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
@@ -1,6 +1,7 @@
 package com.project.baedalsodae.menu.controller;
 
 import com.project.baedalsodae.global.common.ApiResponse;
+import com.project.baedalsodae.global.common.SuccessCode;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
@@ -23,26 +24,27 @@ public class MenuItemController {
     public ResponseEntity<ApiResponse<MenuItemResponseDto>> updateMenuItem(
             @PathVariable UUID menuItemId, @RequestBody MenuItemPutRequestDto request) {
         MenuItemResponseDto response = menuItemService.updateMenuItem(menuItemId, request);
-        return ResponseEntity.ok(ApiResponse.success("", response));
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_UPDATED, response));
     }
 
     @PatchMapping("/{menuItemId}")
     public ResponseEntity<ApiResponse<MenuItemResponseDto>> patchMenuItem(
             @PathVariable UUID menuItemId, @RequestBody MenuItemPatchRequestDto request) {
         MenuItemResponseDto response = menuItemService.patchMenuItem(menuItemId, request);
-        return ResponseEntity.ok(ApiResponse.success("", response));
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_UPDATED, response));
     }
 
     @PatchMapping("/{menuItemId}/orders")
     public ResponseEntity<ApiResponse<MenuItemResponseDto>> updateMenuItemOrder(
             @PathVariable UUID menuItemId, @RequestParam @Validated @Positive Integer order) {
         MenuItemResponseDto response = menuItemService.updateMenuItemOrder(menuItemId, order);
-        return ResponseEntity.ok(ApiResponse.success("", response));
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.MENU_ITEM_ORDER_UPDATED, response));
     }
 
     @DeleteMapping("/{menuItemId}")
     public ResponseEntity<ApiResponse<Void>> deleteMenuItem(@PathVariable UUID menuItemId) {
         menuItemService.deleteMenuItem(menuItemId);
-        return ResponseEntity.ok(ApiResponse.success(""));
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_DELETED, null));
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/dto/requestDto/category/MenuCategoryPutRequestDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/requestDto/category/MenuCategoryPutRequestDto.java
@@ -1,3 +1,5 @@
 package com.project.baedalsodae.menu.dto.requestDto.category;
 
-public record MenuCategoryPutRequestDto(String name) {}
+import jakarta.validation.constraints.NotBlank;
+
+public record MenuCategoryPutRequestDto(@NotBlank String name) {}

--- a/src/main/java/com/project/baedalsodae/menu/dto/requestDto/item/MenuItemPostRequestDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/requestDto/item/MenuItemPostRequestDto.java
@@ -1,12 +1,14 @@
 package com.project.baedalsodae.menu.dto.requestDto.item;
 
 import com.project.baedalsodae.menu.entity.enums.MenuStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record MenuItemPostRequestDto(
-        String name,
+        @NotBlank String name,
         String description,
         int price,
         boolean isPopular,
-        MenuStatus menuStatus,
+        @NotNull MenuStatus menuStatus,
         List<String> tagNames) {}

--- a/src/main/java/com/project/baedalsodae/menu/dto/requestDto/item/MenuItemPutRequestDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/requestDto/item/MenuItemPutRequestDto.java
@@ -1,14 +1,16 @@
 package com.project.baedalsodae.menu.dto.requestDto.item;
 
 import com.project.baedalsodae.menu.entity.enums.MenuStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 
 public record MenuItemPutRequestDto(
-        String name,
+        @NotBlank String name,
         String description,
         int price,
         boolean isPopular,
-        UUID categoryId,
-        MenuStatus menuStatus,
+        @NotNull UUID categoryId,
+        @NotNull MenuStatus menuStatus,
         List<String> tagNames) {}

--- a/src/main/java/com/project/baedalsodae/menu/entity/MenuCategory.java
+++ b/src/main/java/com/project/baedalsodae/menu/entity/MenuCategory.java
@@ -65,4 +65,8 @@ public class MenuCategory extends BaseAuditEntity implements Orderable {
         super.softDelete(userId);
         this.orderNo = null;
     }
+
+    public boolean hasItem() {
+        return menuItems.stream().anyMatch(item -> !item.isDeleted());
+    }
 }

--- a/src/main/java/com/project/baedalsodae/menu/entity/MenuCategory.java
+++ b/src/main/java/com/project/baedalsodae/menu/entity/MenuCategory.java
@@ -56,7 +56,7 @@ public class MenuCategory extends BaseAuditEntity implements Orderable {
     }
 
     @Override
-    public void changeOrderNo(int orderNo) {
+    public void changeOrderNo(Integer orderNo) {
         this.orderNo = orderNo;
     }
 

--- a/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
+++ b/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
@@ -121,6 +121,6 @@ public class MenuItem extends BaseAuditEntity implements Orderable {
     @Override
     public void softDelete(UUID userId) {
         super.softDelete(userId);
-        this.orderNo = null;
+        if (orderNo != null) this.orderNo = null;
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
+++ b/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
@@ -114,7 +114,7 @@ public class MenuItem extends BaseAuditEntity implements Orderable {
     }
 
     @Override
-    public void changeOrderNo(int orderNo) {
+    public void changeOrderNo(Integer orderNo) {
         this.orderNo = orderNo;
     }
 

--- a/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
+++ b/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
@@ -121,6 +121,6 @@ public class MenuItem extends BaseAuditEntity implements Orderable {
     @Override
     public void softDelete(UUID userId) {
         super.softDelete(userId);
-        if (orderNo != null) this.orderNo = null;
+        this.orderNo = null;
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
@@ -32,4 +32,8 @@ public interface MenuCategoryRepository extends JpaRepository<MenuCategory, UUID
             "SELECT c FROM MenuCategory c WHERE c.store.id = :storeId AND c.isDeleted = false ORDER "
                     + "BY c.orderNo ASC")
     List<MenuCategory> findAllByStoreIdAndDeletedIsFalse(UUID storeId);
+
+    @Query(
+            "SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END FROM MenuCategory c WHERE c.store.id = :storeId AND c.name = :name AND c.isDeleted = false")
+    boolean existsByStoreIdAndNameAndDeletedIsFalse(UUID storeId, String name);
 }

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuCategoryRepository.java
@@ -19,18 +19,15 @@ public interface MenuCategoryRepository extends JpaRepository<MenuCategory, UUID
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(
-            "SELECT c FROM MenuCategory c WHERE c.store.id = :storeId AND c.isDeleted = false ORDER "
-                    + "BY c.orderNo ASC")
+            "SELECT c FROM MenuCategory c WHERE c.store.id = :storeId AND c.isDeleted = false ORDER BY c.orderNo ASC")
     List<MenuCategory> findAllByStoreIdAndDeletedIsFalseWithLock(UUID storeId);
 
     @Query(
-            "SELECT MAX(c.orderNo) FROM MenuCategory c WHERE c.store.id = :storeId "
-                    + "AND c.isDeleted = false")
+            "SELECT MAX(c.orderNo) FROM MenuCategory c WHERE c.store.id = :storeId AND c.isDeleted = false")
     Optional<Integer> findMaxOrderNoByStoreIdAndDeletedIsFalse(UUID storeId);
 
     @Query(
-            "SELECT c FROM MenuCategory c WHERE c.store.id = :storeId AND c.isDeleted = false ORDER "
-                    + "BY c.orderNo ASC")
+            "SELECT c FROM MenuCategory c WHERE c.store.id = :storeId AND c.isDeleted = false ORDER BY c.orderNo ASC")
     List<MenuCategory> findAllByStoreIdAndDeletedIsFalse(UUID storeId);
 
     @Query(

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
@@ -23,8 +23,6 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, UUID> {
                     + "AND i.isDeleted = false")
     Optional<Integer> findMaxOrderNoByMenuCategoryId(UUID menuCategoryId);
 
-    boolean existsByMenuCategoryIdAndNameAndIsDeletedIsFalse(UUID menuCategoryId, String name);
-
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(
             "SELECT i FROM MenuItem i WHERE i.menuCategory.id = :menuCategoryId AND i.isDeleted = false ORDER BY i.orderNo ASC")
@@ -33,4 +31,8 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, UUID> {
     @Query(
             "SELECT i FROM MenuItem i WHERE i.menuCategory.id = :menuCategoryId AND i.isDeleted = false ORDER BY i.orderNo ASC")
     List<MenuItem> findAllByMenuCategoryIdAndIsDeletedIsFalse(UUID menuCategoryId);
+
+    @Query(
+            "SELECT CASE WHEN COUNT(i) > 0 THEN true ELSE false END FROM MenuItem i WHERE i.menuCategory.store.id = :storeId AND i.name = :name AND i.isDeleted = false")
+    boolean existsByStoreIdAndNameAndDeletedIsFalse(UUID storeId, String name);
 }

--- a/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
+++ b/src/main/java/com/project/baedalsodae/menu/repository/MenuItemRepository.java
@@ -14,13 +14,11 @@ import org.springframework.stereotype.Repository;
 public interface MenuItemRepository extends JpaRepository<MenuItem, UUID> {
 
     @Query(
-            "SELECT m FROM MenuItem m join fetch m.menuCategory WHERE m.id = :id AND m.isDeleted ="
-                    + " false")
+            "SELECT m FROM MenuItem m join fetch m.menuCategory WHERE m.id = :id AND m.isDeleted = false")
     Optional<MenuItem> findByIdAndDeletedIsFalse(UUID id);
 
     @Query(
-            "SELECT MAX(i.orderNo) FROM MenuItem i WHERE i.menuCategory.id = :menuCategoryId "
-                    + "AND i.isDeleted = false")
+            "SELECT MAX(i.orderNo) FROM MenuItem i WHERE i.menuCategory.id = :menuCategoryId AND i.isDeleted = false")
     Optional<Integer> findMaxOrderNoByMenuCategoryId(UUID menuCategoryId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuCategoryService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuCategoryService.java
@@ -20,4 +20,6 @@ public interface MenuCategoryService {
             UUID menuCategoryId, MenuCategoryPatchRequestDto request);
 
     List<MenuCategoryResponseDto> getMenuCategories(UUID storeId);
+
+    boolean isDuplicateMenuCategoryName(UUID storeId, String name);
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
@@ -17,7 +17,7 @@ public interface MenuItemService {
 
     void deleteMenuItem(UUID menuItemId);
 
-    boolean isDuplicateMenuItemName(UUID menuCategoryId, String name);
+    boolean isDuplicateMenuItemName(UUID storeId, String name);
 
     MenuItemResponseDto updateMenuItemOrder(UUID menuItemId, Integer order);
 

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -68,6 +68,7 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
                         .findByIdAndDeletedIsFalse(menuCategoryId)
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+        if (menuCategory.hasItem()) throw new BusinessException(ErrorCode.MENU_CATEGORY_HAS_ITEMS);
 
         UUID storeId = menuCategory.getStore().getId();
         List<MenuCategory> menuCategories =

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -68,6 +68,12 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
                         .findByIdAndDeletedIsFalse(menuCategoryId)
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+
+        UUID storeId = menuCategory.getStore().getId();
+        List<MenuCategory> menuCategories =
+                menuCategoryRepository.findAllByStoreIdAndDeletedIsFalseWithLock(storeId);
+
+        OrderUtil.deleteAndShift(menuCategories, menuCategory);
         menuCategory.softDelete(null); // / 토큰 기능 추가 시 수정 필요
     }
 

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -30,10 +30,14 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
     @Transactional
     public MenuCategoryResponseDto createMenuCategory(
             UUID storeId, MenuCategoryPostRequestDto request) {
+
         Store store =
                 storeRepository
                         .findByIdAndIsDeletedIsFalse(storeId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+        if (existsByStoreIdAndNameAndDeletedIsFalse(storeId, request.name())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_MENU_CATEGORY_NAME);
+        }
         int maxOrderNo =
                 menuCategoryRepository
                         .findMaxOrderNoByStoreIdAndDeletedIsFalse((storeId))
@@ -56,6 +60,11 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
                         .findByIdAndDeletedIsFalse(menuCategoryId)
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+        if (!menuCategory.getName().equals(request.name())
+                && existsByStoreIdAndNameAndDeletedIsFalse(
+                        menuCategory.getStore().getId(), request.name())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_MENU_CATEGORY_NAME);
+        }
         menuCategory.changeMenuCategoryName(request.name());
         return MenuCategoryResponseDto.fromEntity(menuCategory);
     }
@@ -112,5 +121,14 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
         List<MenuCategory> menuCategories =
                 menuCategoryRepository.findAllByStoreIdAndDeletedIsFalse(storeId);
         return MenuCategoryResponseDto.fromEntityList(menuCategories);
+    }
+
+    @Override
+    public boolean isDuplicateMenuCategoryName(UUID storeId, String name) {
+        return existsByStoreIdAndNameAndDeletedIsFalse(storeId, name);
+    }
+
+    private boolean existsByStoreIdAndNameAndDeletedIsFalse(UUID storeId, String name) {
+        return menuCategoryRepository.existsByStoreIdAndNameAndDeletedIsFalse(storeId, name);
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -31,17 +31,11 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
     public MenuCategoryResponseDto createMenuCategory(
             UUID storeId, MenuCategoryPostRequestDto request) {
 
-        Store store =
-                storeRepository
-                        .findByIdAndIsDeletedIsFalse(storeId)
-                        .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+        Store store = getStoreByStoreId(storeId);
         if (existsByStoreIdAndNameAndDeletedIsFalse(storeId, request.name())) {
             throw new BusinessException(ErrorCode.DUPLICATE_MENU_CATEGORY_NAME);
         }
-        int maxOrderNo =
-                menuCategoryRepository
-                        .findMaxOrderNoByStoreIdAndDeletedIsFalse((storeId))
-                        .orElse(0);
+        int maxOrderNo = getMaxOrderNo(storeId);
         MenuCategory menuCategory = MenuCategory.create(store, request.name(), maxOrderNo + 1);
         try {
             menuCategoryRepository.save(menuCategory);
@@ -55,11 +49,8 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
     @Transactional
     public MenuCategoryResponseDto updateMenuCategory(
             UUID menuCategoryId, MenuCategoryPutRequestDto request) {
-        MenuCategory menuCategory =
-                menuCategoryRepository
-                        .findByIdAndDeletedIsFalse(menuCategoryId)
-                        .orElseThrow(
-                                () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+
+        MenuCategory menuCategory = getMenuCategoryByMenuCategoryId(menuCategoryId);
         if (!menuCategory.getName().equals(request.name())
                 && existsByStoreIdAndNameAndDeletedIsFalse(
                         menuCategory.getStore().getId(), request.name())) {
@@ -72,11 +63,8 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
     @Override
     @Transactional
     public void deleteMenuCategory(UUID menuCategoryId) {
-        MenuCategory menuCategory =
-                menuCategoryRepository
-                        .findByIdAndDeletedIsFalse(menuCategoryId)
-                        .orElseThrow(
-                                () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+
+        MenuCategory menuCategory = getMenuCategoryByMenuCategoryId(menuCategoryId);
         if (menuCategory.hasItem()) throw new BusinessException(ErrorCode.MENU_CATEGORY_HAS_ITEMS);
 
         UUID storeId = menuCategory.getStore().getId();
@@ -91,11 +79,7 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
     @Transactional
     public MenuCategoryResponseDto updateMenuCategoryOrder(
             UUID menuCategoryId, MenuCategoryPatchRequestDto request) {
-        MenuCategory menuCategory =
-                menuCategoryRepository
-                        .findByIdAndDeletedIsFalse(menuCategoryId)
-                        .orElseThrow(
-                                () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+        MenuCategory menuCategory = getMenuCategoryByMenuCategoryId(menuCategoryId);
         Integer from = menuCategory.getOrderNo();
         if (from == null) {
             throw new BusinessException(ErrorCode.INVALID_MENU_CATEGORY_ORDER);
@@ -130,5 +114,21 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
 
     private boolean existsByStoreIdAndNameAndDeletedIsFalse(UUID storeId, String name) {
         return menuCategoryRepository.existsByStoreIdAndNameAndDeletedIsFalse(storeId, name);
+    }
+
+    private Store getStoreByStoreId(UUID storeId) {
+        return storeRepository
+                .findByIdAndIsDeletedIsFalse(storeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+    }
+
+    private MenuCategory getMenuCategoryByMenuCategoryId(UUID menuCategoryId) {
+        return menuCategoryRepository
+                .findByIdAndDeletedIsFalse(menuCategoryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+    }
+
+    private int getMaxOrderNo(UUID storeId) {
+        return menuCategoryRepository.findMaxOrderNoByStoreIdAndDeletedIsFalse(storeId).orElse(0);
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -14,6 +14,7 @@ import com.project.baedalsodae.menu.repository.MenuItemRepository;
 import com.project.baedalsodae.menu.service.MenuItemService;
 import com.project.baedalsodae.tag.service.TagMappingService;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -36,7 +37,8 @@ public class MenuItemServiceImpl implements MenuItemService {
                         .findByIdAndDeletedIsFalse(menuCategoryId)
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
-        if (existsByNameAndMenuCategoryIdAndDeletedIsFalse(menuCategoryId, request.name())) {
+        UUID storeId = category.getStore().getId();
+        if (existsByStoreIdAndNameAndDeletedIsFalse(storeId, request.name())) {
             throw new BusinessException(ErrorCode.DUPLICATE_MENU_ITEM_NAME);
         }
         int maxOrderNo =
@@ -70,6 +72,12 @@ public class MenuItemServiceImpl implements MenuItemService {
                         .findByIdAndDeletedIsFalse(request.categoryId())
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+
+        UUID storeId = category.getStore().getId();
+        if (!Objects.equals(item.getName(), request.name())
+                && existsByStoreIdAndNameAndDeletedIsFalse(storeId, request.name())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_MENU_ITEM_NAME);
+        }
         item.changeMenuInfo(
                 request.name(),
                 request.description(),
@@ -89,15 +97,28 @@ public class MenuItemServiceImpl implements MenuItemService {
                 menuItemRepository
                         .findByIdAndDeletedIsFalse(menuItemId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
-        if (request.categoryId() != null) {
-            MenuCategory category =
+        UUID currentCategoryId = item.getMenuCategory().getId();
+        MenuCategory category =
+                menuCategoryRepository
+                        .findByIdAndDeletedIsFalse(currentCategoryId)
+                        .orElseThrow(
+                                () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+        UUID storeId = category.getStore().getId();
+        if (request.name() != null) {
+            if (!Objects.equals(item.getName(), request.name())
+                    && existsByStoreIdAndNameAndDeletedIsFalse(storeId, request.name())) {
+                throw new BusinessException(ErrorCode.DUPLICATE_MENU_ITEM_NAME);
+            }
+            item.changeName(request.name());
+        }
+        if (request.categoryId() != null && !currentCategoryId.equals(request.categoryId())) {
+            MenuCategory newCategory =
                     menuCategoryRepository
                             .findByIdAndDeletedIsFalse(request.categoryId())
                             .orElseThrow(
                                     () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
-            item.changeMenuCategory(category);
+            item.changeMenuCategory(newCategory);
         }
-        if (request.name() != null) item.changeName(request.name());
         if (request.description() != null) item.changeDescription(request.description());
         if (request.price() != null) item.changePrice(request.price());
         if (request.isPopular() != null) item.changeIsPopular(request.isPopular());
@@ -126,8 +147,8 @@ public class MenuItemServiceImpl implements MenuItemService {
     }
 
     @Override
-    public boolean isDuplicateMenuItemName(UUID menuCategoryId, String name) {
-        return existsByNameAndMenuCategoryIdAndDeletedIsFalse(menuCategoryId, name);
+    public boolean isDuplicateMenuItemName(UUID storeId, String name) {
+        return existsByStoreIdAndNameAndDeletedIsFalse(storeId, name);
     }
 
     @Transactional
@@ -166,9 +187,7 @@ public class MenuItemServiceImpl implements MenuItemService {
         return menuItems.stream().map(MenuItemResponseDto::fromEntity).toList();
     }
 
-    private boolean existsByNameAndMenuCategoryIdAndDeletedIsFalse(
-            UUID menuCategoryId, String name) {
-        return menuItemRepository.existsByMenuCategoryIdAndNameAndIsDeletedIsFalse(
-                menuCategoryId, name);
+    private boolean existsByStoreIdAndNameAndDeletedIsFalse(UUID storeId, String name) {
+        return menuItemRepository.existsByStoreIdAndNameAndDeletedIsFalse(storeId, name);
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -116,6 +116,12 @@ public class MenuItemServiceImpl implements MenuItemService {
                 menuItemRepository
                         .findByIdAndDeletedIsFalse(menuItemId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
+        UUID menuCategoryId = item.getMenuCategory().getId();
+
+        List<MenuItem> menuItems =
+                menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalseWithLock(
+                        menuCategoryId);
+        OrderUtil.deleteAndShift(menuItems, item);
         item.softDelete(null); // 토큰 기능 추가 시 수정 필요
     }
 

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -32,11 +32,7 @@ public class MenuItemServiceImpl implements MenuItemService {
     @Transactional
     @Override
     public MenuItemResponseDto createMenuItem(UUID menuCategoryId, MenuItemPostRequestDto request) {
-        MenuCategory category =
-                menuCategoryRepository
-                        .findByIdAndDeletedIsFalse(menuCategoryId)
-                        .orElseThrow(
-                                () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+        MenuCategory category = getMenuCategoryByMenuCategoryId(menuCategoryId);
         UUID storeId = category.getStore().getId();
         if (existsByStoreIdAndNameAndDeletedIsFalse(storeId, request.name())) {
             throw new BusinessException(ErrorCode.DUPLICATE_MENU_ITEM_NAME);
@@ -67,11 +63,7 @@ public class MenuItemServiceImpl implements MenuItemService {
                 menuItemRepository
                         .findByIdAndDeletedIsFalse(menuItemId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
-        MenuCategory category =
-                menuCategoryRepository
-                        .findByIdAndDeletedIsFalse(request.categoryId())
-                        .orElseThrow(
-                                () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+        MenuCategory category = getMenuCategoryByMenuCategoryId(request.categoryId());
 
         UUID storeId = category.getStore().getId();
         if (!Objects.equals(item.getName(), request.name())
@@ -98,11 +90,7 @@ public class MenuItemServiceImpl implements MenuItemService {
                         .findByIdAndDeletedIsFalse(menuItemId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
         UUID currentCategoryId = item.getMenuCategory().getId();
-        MenuCategory category =
-                menuCategoryRepository
-                        .findByIdAndDeletedIsFalse(currentCategoryId)
-                        .orElseThrow(
-                                () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+        MenuCategory category = getMenuCategoryByMenuCategoryId(currentCategoryId);
         UUID storeId = category.getStore().getId();
         if (request.name() != null) {
             if (!Objects.equals(item.getName(), request.name())
@@ -112,11 +100,7 @@ public class MenuItemServiceImpl implements MenuItemService {
             item.changeName(request.name());
         }
         if (request.categoryId() != null && !currentCategoryId.equals(request.categoryId())) {
-            MenuCategory newCategory =
-                    menuCategoryRepository
-                            .findByIdAndDeletedIsFalse(request.categoryId())
-                            .orElseThrow(
-                                    () -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+            MenuCategory newCategory = getMenuCategoryByMenuCategoryId(request.categoryId());
             item.changeMenuCategory(newCategory);
         }
         if (request.description() != null) item.changeDescription(request.description());
@@ -189,5 +173,11 @@ public class MenuItemServiceImpl implements MenuItemService {
 
     private boolean existsByStoreIdAndNameAndDeletedIsFalse(UUID storeId, String name) {
         return menuItemRepository.existsByStoreIdAndNameAndDeletedIsFalse(storeId, name);
+    }
+
+    private MenuCategory getMenuCategoryByMenuCategoryId(UUID menuCategoryId) {
+        return menuCategoryRepository
+                .findByIdAndDeletedIsFalse(menuCategoryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
+++ b/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
@@ -71,4 +71,12 @@ public class StoreController {
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.MENU_CATEGORY_LIST_FOUND, response));
     }
+
+    @GetMapping("/{storeId}/menu-categories/duplicate-check")
+    public ResponseEntity<ApiResponse<Boolean>> checkDuplicateMenuCategoryName(
+            @PathVariable UUID storeId, @RequestParam String name) {
+        boolean isDuplicate = menuCategoryService.isDuplicateMenuCategoryName(storeId, name);
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.MENU_CATEGORY_NAME_DUPLICATE_CHECKED, isDuplicate));
+    }
 }

--- a/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
+++ b/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
@@ -5,6 +5,7 @@ import com.project.baedalsodae.global.common.SuccessCode;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
 import com.project.baedalsodae.menu.service.MenuCategoryService;
+import com.project.baedalsodae.menu.service.MenuItemService;
 import com.project.baedalsodae.store.dto.request.CreateStoreRequest;
 import com.project.baedalsodae.store.dto.request.UpdateStoreRequest;
 import com.project.baedalsodae.store.dto.request.UpdateStoreStatusRequest;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class StoreController {
     private final StoreCommandService storeCommandService;
     private final MenuCategoryService menuCategoryService;
+    private final MenuItemService menuItemService;
 
     // TODO 인증 도메인 완료되면, userId 추가
     @PostMapping
@@ -78,5 +80,13 @@ public class StoreController {
         boolean isDuplicate = menuCategoryService.isDuplicateMenuCategoryName(storeId, name);
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.MENU_CATEGORY_NAME_DUPLICATE_CHECKED, isDuplicate));
+    }
+
+    @GetMapping("/{storeId}/menu-items/duplicate-check")
+    public ResponseEntity<ApiResponse<Boolean>> checkDuplicateMenuItemName(
+            @PathVariable UUID storeId, @RequestParam String name) {
+        boolean isDuplicate = menuItemService.isDuplicateMenuItemName(storeId, name);
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.MENU_ITEM_NAME_DUPLICATE_CHECKED, isDuplicate));
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #65
- 
### 💡 작업 내용
- MenuCategory와 MenuItem의 공통 순서 관련 로직을 Orderable 인터페이스와 OrderUtil로 통합해 중복 제거
- 삭제 시 빈 순서가 생기지 않도록 deleteAndShift로 뒤 항목들의 orderNo를 자동으로 당겨줌
- 같은 가게 내에서 카테고리가 달라도 메뉴 이름이 동일하면 혼란이 생길 수 있어 중복 체크 범위를 가게 단위로 확대
- 카테고리 삭제 전 아이템 존재 여부를 체크해 데이터 정합성 보호

### 🔍 변경 이유
- 삭제 시 순서 재정렬 되고 있지 않아 버그 유발
- 가게 내 동일한 메뉴 이름을 가지는 것이 문제가 될수 있어 기존 중복 체크 범위 확대

### 📝 리뷰 포인트 
  - `OrderUtil.deleteAndShift` — 삭제 대상이 리스트에 포함된 채로 호출되므로 null 체크 조건 확인
  - 이름 수정 시 자기 자신의 현재 이름은 중복 체크에서 제외하는 로직 확인

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)