### PR TITLE
Test/96 menucategory testcode

### DIFF
--- a/src/test/java/com/project/baedalsodae/menu/fixture/MenuCategoryMockFixture.java
+++ b/src/test/java/com/project/baedalsodae/menu/fixture/MenuCategoryMockFixture.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import com.project.baedalsodae.menu.entity.MenuCategory;
 import com.project.baedalsodae.menu.repository.MenuCategoryRepository;
 import com.project.baedalsodae.store.entity.Store;
+import com.project.baedalsodae.store.repository.StoreRepository;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,7 +18,14 @@ public class MenuCategoryMockFixture {
         throw new AssertionError("Utility class should not be instantiated");
     }
 
-    public static CategoryAndStoreFixture createCategoryAndStoreFixture(
+    public static Store createMockStoreWithRepository(
+            StoreRepository storeRepository, UUID storeId) {
+        Store store = mock(Store.class);
+        given(storeRepository.findByIdAndIsDeletedIsFalse(storeId)).willReturn(Optional.of(store));
+        return store;
+    }
+
+    public static MenuCategory createMockCategoryWithRepository(
             MenuCategoryRepository menuCategoryRepository, UUID menuCategoryId, UUID storeId) {
         MenuCategory category = mock(MenuCategory.class);
         Store store = mock(Store.class);
@@ -26,14 +34,27 @@ public class MenuCategoryMockFixture {
         lenient().when(category.getStore()).thenReturn(store);
         lenient().when(store.getId()).thenReturn(storeId);
         lenient().when(category.getId()).thenReturn(menuCategoryId);
+        given(category.getName()).willReturn(DEFAULT_CATEGORY_NAME);
+        return category;
+    }
+
+    public static CategoryAndStoreFixture createCategoryAndStoreFixture(
+            MenuCategoryRepository menuCategoryRepository, UUID menuCategoryId, UUID storeId) {
+        MenuCategory category = mock(MenuCategory.class);
+        Store store = mock(Store.class);
+        given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
+                .willReturn(Optional.of(category));
+        given(category.getStore()).willReturn(store);
+        given(store.getId()).willReturn(storeId);
+        lenient().when(category.getId()).thenReturn(menuCategoryId);
         lenient().when(category.getName()).thenReturn(DEFAULT_CATEGORY_NAME);
         return new CategoryAndStoreFixture(category, store);
     }
 
     public static MenuCategory createMockCategory(UUID categoryId, String categoryName) {
         MenuCategory category = mock(MenuCategory.class);
-        lenient().when(category.getId()).thenReturn(categoryId);
-        lenient().when(category.getName()).thenReturn(categoryName);
+        given(category.getId()).willReturn(categoryId);
+        given(category.getName()).willReturn(categoryName);
         return category;
     }
 

--- a/src/test/java/com/project/baedalsodae/menu/fixture/MenuCategoryRequestFixture.java
+++ b/src/test/java/com/project/baedalsodae/menu/fixture/MenuCategoryRequestFixture.java
@@ -1,0 +1,20 @@
+package com.project.baedalsodae.menu.fixture;
+
+import static com.project.baedalsodae.menu.fixture.MenuTestConstants.*;
+
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
+
+public class MenuCategoryRequestFixture {
+
+    private MenuCategoryRequestFixture() {
+        throw new AssertionError("Utility class should not be instantiated");
+    }
+
+    public static MenuCategoryPostRequestDto createDefaultPostRequest() {
+        return new MenuCategoryPostRequestDto(DEFAULT_CATEGORY_NAME);
+    }
+
+    public static MenuCategoryPostRequestDto createPostRequestWithName(String name) {
+        return new MenuCategoryPostRequestDto(name);
+    }
+}

--- a/src/test/java/com/project/baedalsodae/menu/fixture/MenuCategoryRequestFixture.java
+++ b/src/test/java/com/project/baedalsodae/menu/fixture/MenuCategoryRequestFixture.java
@@ -3,6 +3,7 @@ package com.project.baedalsodae.menu.fixture;
 import static com.project.baedalsodae.menu.fixture.MenuTestConstants.*;
 
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
 
 public class MenuCategoryRequestFixture {
 
@@ -16,5 +17,13 @@ public class MenuCategoryRequestFixture {
 
     public static MenuCategoryPostRequestDto createPostRequestWithName(String name) {
         return new MenuCategoryPostRequestDto(name);
+    }
+
+    public static MenuCategoryPutRequestDto createDefaultPutRequest() {
+        return new MenuCategoryPutRequestDto(DEFAULT_CATEGORY_NAME);
+    }
+
+    public static MenuCategoryPutRequestDto createPutRequestWithName(String name) {
+        return new MenuCategoryPutRequestDto(name);
     }
 }

--- a/src/test/java/com/project/baedalsodae/menu/fixture/MenuCategoryRequestFixture.java
+++ b/src/test/java/com/project/baedalsodae/menu/fixture/MenuCategoryRequestFixture.java
@@ -2,6 +2,7 @@ package com.project.baedalsodae.menu.fixture;
 
 import static com.project.baedalsodae.menu.fixture.MenuTestConstants.*;
 
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
 
@@ -25,5 +26,9 @@ public class MenuCategoryRequestFixture {
 
     public static MenuCategoryPutRequestDto createPutRequestWithName(String name) {
         return new MenuCategoryPutRequestDto(name);
+    }
+
+    public static MenuCategoryPatchRequestDto createPatchRequest(int orderNo) {
+        return new MenuCategoryPatchRequestDto(orderNo);
     }
 }

--- a/src/test/java/com/project/baedalsodae/menu/fixture/MenuTestConstants.java
+++ b/src/test/java/com/project/baedalsodae/menu/fixture/MenuTestConstants.java
@@ -6,22 +6,26 @@ public final class MenuTestConstants {
         throw new AssertionError("Utility class should not be instantiated");
     }
 
-    // orderNo
+    public static final String ERROR_CODE_FIELD = "errorCode";
+
+    // ORDER NUMBER
     public static final int FIRST_ORDER_NUMBER = 1;
     public static final int SECOND_ORDER_NUMBER = 2;
     public static final int THIRD_ORDER_NUMBER = 3;
     public static final int EXISTING_MAX_ORDER_NUMBER = 2;
 
-    // MenuItem
+    // MENU ITEM
     public static final String DEFAULT_MENU_ITEM_NAME = "후라이드치킨";
     public static final String DEFAULT_ITEM_DESCRIPTION = "바삭한 후라이드";
     public static final int DEFAULT_ITEM_PRICE = 18000;
-
-    // Alternative MenuItem
     public static final String ALTERNATIVE_MENU_ITEM_NAME = "양념치킨";
     public static final String ALTERNATIVE_ITEM_DESCRIPTION = "달콤한 양념";
     public static final int ALTERNATIVE_ITEM_PRICE = 19000;
 
-    // MenuCategory
+    // MENU CATEGORY
     public static final String DEFAULT_CATEGORY_NAME = "치킨류";
+    public static final String ALTERNATIVE_CATEGORY_NAME = "피자류";
+    public static final String NEW_CATEGORY_NAME = "새 카테고리";
+    public static final String DUPLICATE_CATEGORY_NAME = "중복이름";
+    public static final String NEW_UNIQUE_CATEGORY_NAME = "신카테고리";
 }

--- a/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.*;
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
 import com.project.baedalsodae.menu.entity.MenuCategory;
 import com.project.baedalsodae.menu.repository.MenuCategoryRepository;
@@ -149,6 +150,85 @@ class MenuCategoryServiceImplTest {
             // then
             assertThat(result.name()).isEqualTo(DEFAULT_CATEGORY_NAME);
             assertThat(result.orderNo()).isEqualTo(EXISTING_MAX_ORDER_NUMBER + 1);
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 카테고리 전체 수정")
+    class UpdateMenuCategory {
+
+        @Test
+        @DisplayName("실패: 카테고리가 존재하지 않으면 예외가 발생한다")
+        void updateMenuCategory_fail_notFound() {
+            // given
+            MenuCategoryPutRequestDto request = createPutRequestWithName(NEW_CATEGORY_NAME);
+            given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                            () -> menuCategoryService.updateMenuCategory(menuCategoryId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 변경하려는 이름이 이미 존재하면 예외가 발생한다")
+        void updateMenuCategory_fail_duplicateName() {
+            // given
+            MenuCategoryPutRequestDto request = createPutRequestWithName(DUPLICATE_CATEGORY_NAME);
+            createMockCategoryWithRepository(menuCategoryRepository, menuCategoryId, storeId);
+            given(
+                            menuCategoryRepository.existsByStoreIdAndNameAndDeletedIsFalse(
+                                    storeId, DUPLICATE_CATEGORY_NAME))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(
+                            () -> menuCategoryService.updateMenuCategory(menuCategoryId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.DUPLICATE_MENU_CATEGORY_NAME);
+        }
+
+        @Test
+        @DisplayName("성공: 이름이 같으면 중복 체크 없이 수정된다")
+        void updateMenuCategory_success_sameName() {
+            // given
+            MenuCategoryPutRequestDto request = createDefaultPutRequest();
+            MenuCategory category =
+                    createMockCategoryWithRepository(
+                            menuCategoryRepository, menuCategoryId, storeId);
+            given(category.getOrderNo()).willReturn(FIRST_ORDER_NUMBER);
+
+            // when
+            menuCategoryService.updateMenuCategory(menuCategoryId, request);
+
+            // then
+            verify(menuCategoryRepository, never())
+                    .existsByStoreIdAndNameAndDeletedIsFalse(any(), any());
+        }
+
+        @Test
+        @DisplayName("성공: 카테고리 이름을 변경한다")
+        void updateMenuCategory_success() {
+            // given
+            MenuCategoryPutRequestDto request = createPutRequestWithName(NEW_CATEGORY_NAME);
+            MenuCategory category =
+                    createMockCategoryWithRepository(
+                            menuCategoryRepository, menuCategoryId, storeId);
+            given(
+                            menuCategoryRepository.existsByStoreIdAndNameAndDeletedIsFalse(
+                                    storeId, NEW_CATEGORY_NAME))
+                    .willReturn(false);
+            given(category.getOrderNo()).willReturn(FIRST_ORDER_NUMBER);
+
+            // when
+            menuCategoryService.updateMenuCategory(menuCategoryId, request);
+
+            // then
+            verify(category).changeMenuCategoryName(NEW_CATEGORY_NAME);
         }
     }
 

--- a/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.*;
 
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
@@ -229,6 +230,101 @@ class MenuCategoryServiceImplTest {
 
             // then
             verify(category).changeMenuCategoryName(NEW_CATEGORY_NAME);
+        }
+    }
+
+
+    @Nested
+    @DisplayName("메뉴 카테고리 순서 변경")
+    class UpdateMenuCategoryOrder {
+
+        private MenuCategory category;
+
+        private void givenCategoryExistsWithOrder(int orderNo) {
+            category = mock(MenuCategory.class);
+            Store store = mock(Store.class);
+            given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
+                    .willReturn(Optional.of(category));
+            given(category.getOrderNo()).willReturn(orderNo);
+            given(category.getId()).willReturn(menuCategoryId);
+            given(category.getName()).willReturn(DEFAULT_CATEGORY_NAME);
+            lenient().when(category.getStore()).thenReturn(store);
+            lenient().when(store.getId()).thenReturn(storeId);
+        }
+
+        @Test
+        @DisplayName("실패: 카테고리가 존재하지 않으면 예외가 발생한다")
+        void updateMenuCategoryOrder_fail_notFound() {
+            // given
+            MenuCategoryPatchRequestDto request = createPatchRequest(THIRD_ORDER_NUMBER);
+            given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.updateMenuCategoryOrder(
+                                            menuCategoryId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: orderNo가 null이면 예외가 발생한다")
+        void updateMenuCategoryOrder_fail_invalidOrder() {
+            // given
+            MenuCategoryPatchRequestDto request = createPatchRequest(THIRD_ORDER_NUMBER);
+            category = mock(MenuCategory.class);
+            given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
+                    .willReturn(Optional.of(category));
+            given(category.getOrderNo()).willReturn(null);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.updateMenuCategoryOrder(
+                                            menuCategoryId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.INVALID_MENU_CATEGORY_ORDER);
+        }
+
+        @Test
+        @DisplayName("성공: 현재 순서와 동일하면 목록 조회 없이 바로 반환한다")
+        void updateMenuCategoryOrder_success_sameOrder() {
+            // given
+            MenuCategoryPatchRequestDto request = createPatchRequest(SECOND_ORDER_NUMBER);
+            givenCategoryExistsWithOrder(SECOND_ORDER_NUMBER);
+
+            // when
+            menuCategoryService.updateMenuCategoryOrder(menuCategoryId, request);
+
+            // then
+            verify(menuCategoryRepository, never())
+                    .findAllByStoreIdAndDeletedIsFalseWithLock(any());
+        }
+
+        @Test
+        @DisplayName("성공: 1번에서 3번으로 이동 시 사이 순서가 앞으로 당겨진다")
+        void updateMenuCategoryOrder_success_moveDown() {
+            // given
+            MenuCategoryPatchRequestDto request = createPatchRequest(THIRD_ORDER_NUMBER);
+            MenuCategory category2 = mock(MenuCategory.class);
+            MenuCategory category3 = mock(MenuCategory.class);
+            givenCategoryExistsWithOrder(FIRST_ORDER_NUMBER);
+            given(category2.getOrderNo()).willReturn(SECOND_ORDER_NUMBER);
+            given(category3.getOrderNo()).willReturn(THIRD_ORDER_NUMBER);
+            given(menuCategoryRepository.findAllByStoreIdAndDeletedIsFalseWithLock(storeId))
+                    .willReturn(List.of(category, category2, category3));
+
+            // when
+            menuCategoryService.updateMenuCategoryOrder(menuCategoryId, request);
+
+            // then
+            verify(category).changeOrderNo(THIRD_ORDER_NUMBER);
+            verify(category2).changeOrderNo(FIRST_ORDER_NUMBER);
+            verify(category3).changeOrderNo(SECOND_ORDER_NUMBER);
         }
     }
 

--- a/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
@@ -401,4 +401,83 @@ class MenuCategoryServiceImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("메뉴 카테고리 목록 조회")
+    class GetMenuCategories {
+
+        @Test
+        @DisplayName("성공: 가게에 카테고리가 없으면 빈 목록을 반환한다")
+        void getMenuCategories_success_empty() {
+            // given
+            given(menuCategoryRepository.findAllByStoreIdAndDeletedIsFalse(storeId))
+                    .willReturn(List.of());
+
+            // when
+            List<MenuCategoryResponseDto> result = menuCategoryService.getMenuCategories(storeId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("성공: 가게에 속한 카테고리 목록을 orderNo 순으로 반환한다")
+        void getMenuCategories_success() {
+            // given
+            MenuCategory category1 = createMockCategory(UUID.randomUUID(), DEFAULT_CATEGORY_NAME);
+            MenuCategory category2 =
+                    createMockCategory(UUID.randomUUID(), ALTERNATIVE_CATEGORY_NAME);
+            given(category1.getOrderNo()).willReturn(FIRST_ORDER_NUMBER);
+            given(category2.getOrderNo()).willReturn(SECOND_ORDER_NUMBER);
+            given(menuCategoryRepository.findAllByStoreIdAndDeletedIsFalse(storeId))
+                    .willReturn(List.of(category1, category2));
+
+            // when
+            List<MenuCategoryResponseDto> result = menuCategoryService.getMenuCategories(storeId);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).name()).isEqualTo(DEFAULT_CATEGORY_NAME);
+            assertThat(result.get(1).name()).isEqualTo(ALTERNATIVE_CATEGORY_NAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 카테고리 이름 중복 확인")
+    class IsDuplicateMenuCategoryName {
+
+        @Test
+        @DisplayName("중복 이름이 없으면 false를 반환한다")
+        void isDuplicateMenuCategoryName_false() {
+            // given
+            given(
+                            menuCategoryRepository.existsByStoreIdAndNameAndDeletedIsFalse(
+                                    storeId, NEW_UNIQUE_CATEGORY_NAME))
+                    .willReturn(false);
+
+            // when
+            boolean result =
+                    menuCategoryService.isDuplicateMenuCategoryName(
+                            storeId, NEW_UNIQUE_CATEGORY_NAME);
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("중복 이름이 있으면 true를 반환한다")
+        void isDuplicateMenuCategoryName_true() {
+            // given
+            given(
+                            menuCategoryRepository.existsByStoreIdAndNameAndDeletedIsFalse(
+                                    storeId, DEFAULT_CATEGORY_NAME))
+                    .willReturn(true);
+
+            // when
+            boolean result =
+                    menuCategoryService.isDuplicateMenuCategoryName(storeId, DEFAULT_CATEGORY_NAME);
+
+            // then
+            assertThat(result).isTrue();
+        }
+    }
 }

--- a/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
@@ -233,6 +233,79 @@ class MenuCategoryServiceImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("메뉴 카테고리 삭제")
+    class DeleteMenuCategory {
+
+        private MenuCategory targetCategory;
+        private MenuCategory category1;
+        private MenuCategory category3;
+
+        private void givenCategoriesForDeletion() {
+            targetCategory = mock(MenuCategory.class);
+            Store store = mock(Store.class);
+            given(targetCategory.getStore()).willReturn(store);
+            given(store.getId()).willReturn(storeId);
+            given(targetCategory.getOrderNo()).willReturn(SECOND_ORDER_NUMBER);
+            given(targetCategory.hasItem()).willReturn(false);
+
+            category1 = mock(MenuCategory.class);
+            given(category1.getOrderNo()).willReturn(FIRST_ORDER_NUMBER);
+
+            category3 = mock(MenuCategory.class);
+            given(category3.getOrderNo()).willReturn(THIRD_ORDER_NUMBER);
+
+            given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
+                    .willReturn(Optional.of(targetCategory));
+            given(menuCategoryRepository.findAllByStoreIdAndDeletedIsFalseWithLock(storeId))
+                    .willReturn(List.of(category1, targetCategory, category3));
+        }
+
+        @Test
+        @DisplayName("실패: 카테고리가 존재하지 않으면 예외가 발생한다")
+        void deleteMenuCategory_fail_notFound() {
+            // given
+            given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> menuCategoryService.deleteMenuCategory(menuCategoryId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 카테고리에 아이템이 존재하면 예외가 발생한다")
+        void deleteMenuCategory_fail_hasItems() {
+            // given
+            MenuCategory category = mock(MenuCategory.class);
+            given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
+                    .willReturn(Optional.of(category));
+            given(category.hasItem()).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> menuCategoryService.deleteMenuCategory(menuCategoryId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_HAS_ITEMS);
+        }
+
+        @Test
+        @DisplayName("성공: 카테고리를 소프트 삭제하고 뒤의 순서를 앞으로 당긴다")
+        void deleteMenuCategory_success() {
+            // given
+            givenCategoriesForDeletion();
+
+            // when
+            menuCategoryService.deleteMenuCategory(menuCategoryId);
+
+            // then
+            verify(targetCategory).softDelete(null);
+            verify(category3).changeOrderNo(SECOND_ORDER_NUMBER);
+            verify(category1, never()).changeOrderNo(any());
+        }
+    }
 
     @Nested
     @DisplayName("메뉴 카테고리 순서 변경")

--- a/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
@@ -1,0 +1,155 @@
+package com.project.baedalsodae.menu.service;
+
+import static com.project.baedalsodae.menu.fixture.MenuCategoryMockFixture.*;
+import static com.project.baedalsodae.menu.fixture.MenuCategoryRequestFixture.*;
+import static com.project.baedalsodae.menu.fixture.MenuTestConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+import com.project.baedalsodae.global.common.BusinessException;
+import com.project.baedalsodae.global.common.ErrorCode;
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
+import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
+import com.project.baedalsodae.menu.entity.MenuCategory;
+import com.project.baedalsodae.menu.repository.MenuCategoryRepository;
+import com.project.baedalsodae.menu.service.impl.MenuCategoryServiceImpl;
+import com.project.baedalsodae.store.entity.Store;
+import com.project.baedalsodae.store.repository.StoreRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class MenuCategoryServiceImplTest {
+
+    @Mock private MenuCategoryRepository menuCategoryRepository;
+    @Mock private StoreRepository storeRepository;
+
+    @InjectMocks private MenuCategoryServiceImpl menuCategoryService;
+
+    private UUID storeId;
+    private UUID menuCategoryId;
+
+    @BeforeEach
+    void setUp() {
+        storeId = UUID.randomUUID();
+        menuCategoryId = UUID.randomUUID();
+    }
+
+    @Nested
+    @DisplayName("메뉴 카테고리 생성")
+    class CreateMenuCategory {
+
+        private final MenuCategoryPostRequestDto request = createDefaultPostRequest();
+
+        @Test
+        @DisplayName("실패: 가게가 존재하지 않으면 예외가 발생한다")
+        void createMenuCategory_fail_storeNotFound() {
+            // given
+            given(storeRepository.findByIdAndIsDeletedIsFalse(storeId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> menuCategoryService.createMenuCategory(storeId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.STORE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 같은 가게에 동일한 이름의 카테고리가 있으면 예외가 발생한다")
+        void createMenuCategory_fail_duplicateName() {
+            // given
+            createMockStoreWithRepository(storeRepository, storeId);
+            given(
+                            menuCategoryRepository.existsByStoreIdAndNameAndDeletedIsFalse(
+                                    storeId, DEFAULT_CATEGORY_NAME))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> menuCategoryService.createMenuCategory(storeId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.DUPLICATE_MENU_CATEGORY_NAME);
+        }
+
+        @Test
+        @DisplayName("실패: 순서 저장 중 충돌이 발생하면 예외가 발생한다")
+        void createMenuCategory_fail_orderConflict() {
+            // given
+            createMockStoreWithRepository(storeRepository, storeId);
+            given(
+                            menuCategoryRepository.existsByStoreIdAndNameAndDeletedIsFalse(
+                                    storeId, DEFAULT_CATEGORY_NAME))
+                    .willReturn(false);
+            given(menuCategoryRepository.findMaxOrderNoByStoreIdAndDeletedIsFalse(storeId))
+                    .willReturn(Optional.of(0));
+            given(menuCategoryRepository.save(any(MenuCategory.class)))
+                    .willThrow(new DataIntegrityViolationException("order conflict"));
+
+            // when & then
+            assertThatThrownBy(() -> menuCategoryService.createMenuCategory(storeId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_ORDER_CONFLICT);
+        }
+
+        @Test
+        @DisplayName("성공: 가게에 카테고리가 없으면 orderNo는 1이 된다")
+        void createMenuCategory_success_firstCategory() {
+            // given
+            createMockStoreWithRepository(storeRepository, storeId);
+            given(
+                            menuCategoryRepository.existsByStoreIdAndNameAndDeletedIsFalse(
+                                    storeId, DEFAULT_CATEGORY_NAME))
+                    .willReturn(false);
+            given(menuCategoryRepository.findMaxOrderNoByStoreIdAndDeletedIsFalse(storeId))
+                    .willReturn(Optional.empty());
+            given(menuCategoryRepository.save(any(MenuCategory.class)))
+                    .willAnswer(i -> i.getArgument(0));
+
+            // when
+            MenuCategoryResponseDto result =
+                    menuCategoryService.createMenuCategory(storeId, request);
+
+            // then
+            assertThat(result.orderNo()).isEqualTo(FIRST_ORDER_NUMBER);
+        }
+
+        @Test
+        @DisplayName("성공: 카테고리 생성 시 orderNo는 기존 최대값 + 1이 된다")
+        void createMenuCategory_success() {
+            // given
+            createMockStoreWithRepository(storeRepository, storeId);
+            given(
+                            menuCategoryRepository.existsByStoreIdAndNameAndDeletedIsFalse(
+                                    storeId, DEFAULT_CATEGORY_NAME))
+                    .willReturn(false);
+            given(menuCategoryRepository.findMaxOrderNoByStoreIdAndDeletedIsFalse(storeId))
+                    .willReturn(Optional.of(EXISTING_MAX_ORDER_NUMBER));
+
+            given(menuCategoryRepository.save(any(MenuCategory.class)))
+                    .willAnswer(i -> i.getArgument(0));
+
+            // when
+            MenuCategoryResponseDto result =
+                    menuCategoryService.createMenuCategory(storeId, request);
+
+            // then
+            assertThat(result.name()).isEqualTo(DEFAULT_CATEGORY_NAME);
+            assertThat(result.orderNo()).isEqualTo(EXISTING_MAX_ORDER_NUMBER + 1);
+        }
+    }
+
+}

--- a/src/test/java/com/project/baedalsodae/menu/service/MenuItemServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/menu/service/MenuItemServiceImplTest.java
@@ -40,7 +40,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 @ExtendWith(MockitoExtension.class)
 class MenuItemServiceImplTest {
 
-    public static final String ERROR_CODE = "errorCode";
     @Mock private MenuItemRepository menuItemRepository;
     @Mock private MenuCategoryRepository menuCategoryRepository;
     @Mock private TagMappingService tagMappingService;
@@ -102,7 +101,8 @@ class MenuItemServiceImplTest {
             // when & then
             assertThatThrownBy(() -> menuItemService.createMenuItem(menuCategoryId, request))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.MENU_CATEGORY_NOT_FOUND);
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_NOT_FOUND);
         }
 
         @Test
@@ -118,7 +118,8 @@ class MenuItemServiceImplTest {
             // when & then
             assertThatThrownBy(() -> menuItemService.createMenuItem(menuCategoryId, request))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.DUPLICATE_MENU_ITEM_NAME);
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.DUPLICATE_MENU_ITEM_NAME);
         }
 
         @Test
@@ -138,7 +139,8 @@ class MenuItemServiceImplTest {
             // when & then
             assertThatThrownBy(() -> menuItemService.createMenuItem(menuCategoryId, request))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.MENU_ITEM_ORDER_CONFLICT);
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_ORDER_CONFLICT);
         }
 
         @Test
@@ -227,7 +229,7 @@ class MenuItemServiceImplTest {
             // when & then
             assertThatThrownBy(() -> menuItemService.updateMenuItem(menuItemId, request))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.MENU_ITEM_NOT_FOUND);
+                    .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_NOT_FOUND);
         }
 
         @Test
@@ -245,7 +247,8 @@ class MenuItemServiceImplTest {
             // when & then
             assertThatThrownBy(() -> menuItemService.updateMenuItem(menuItemId, testRequest))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.MENU_CATEGORY_NOT_FOUND);
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_NOT_FOUND);
         }
 
         @Test
@@ -265,7 +268,8 @@ class MenuItemServiceImplTest {
             // when & then
             assertThatThrownBy(() -> menuItemService.updateMenuItem(menuItemId, request))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.DUPLICATE_MENU_ITEM_NAME);
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.DUPLICATE_MENU_ITEM_NAME);
         }
 
         @Test
@@ -363,7 +367,7 @@ class MenuItemServiceImplTest {
             // when & then
             assertThatThrownBy(() -> menuItemService.patchMenuItem(menuItemId, request))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.MENU_ITEM_NOT_FOUND);
+                    .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_NOT_FOUND);
         }
 
         @Test
@@ -379,7 +383,8 @@ class MenuItemServiceImplTest {
             // when & then
             assertThatThrownBy(() -> menuItemService.patchMenuItem(menuItemId, request))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.DUPLICATE_MENU_ITEM_NAME);
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.DUPLICATE_MENU_ITEM_NAME);
         }
 
         @Test
@@ -495,7 +500,7 @@ class MenuItemServiceImplTest {
             // when & then
             assertThatThrownBy(() -> menuItemService.deleteMenuItem(menuItemId))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.MENU_ITEM_NOT_FOUND);
+                    .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_NOT_FOUND);
         }
 
         @Test
@@ -544,7 +549,7 @@ class MenuItemServiceImplTest {
                                     menuItemService.updateMenuItemOrder(
                                             menuItemId, THIRD_ORDER_NUMBER))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.MENU_ITEM_NOT_FOUND);
+                    .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_NOT_FOUND);
         }
 
         @Test
@@ -562,7 +567,8 @@ class MenuItemServiceImplTest {
                                     menuItemService.updateMenuItemOrder(
                                             menuItemId, THIRD_ORDER_NUMBER))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue(ERROR_CODE, ErrorCode.INVALID_MENU_ITEM_ORDER);
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.INVALID_MENU_ITEM_ORDER);
         }
 
         @Test


### PR DESCRIPTION
### 📌 관련 이슈
- close #96
- 
### 💡 작업 내용
- MenuCategoryServiceImpl의 전체 서비스 메서드에 대한 단위 테스트 작성-

### 🔍 변경 이유
  - MenuCategoryServiceImpl의 주요 분기를 테스트로 검증하기 위해
  - 공통 mock 설정을 fixture로 분리해 테스트 간 중복을 줄이고 재사용성 확보
  - 공유 fixture에서 실제로 호출되지 않는 stub은 lenient, 항상 호출되는 stub은 given으로 명시적으로 구분

### 📝 리뷰 포인트 (선택)
  - createMockCategoryWithRepository의 lenient/given 구분: getStore(), store.getId()는 same-name 수정 케이스에서 미호출, getId()는 실패 케이스에서 미호출이라 lenient 유지
  - givenCategoryExistsWithOrder의 getStore(), store.getId()는 sameOrder 조기 반환 케이스에서 미호출이라 lenient 유지


### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)