### PR TITLE
Feat/106 menuitem auth

### DIFF
--- a/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
+++ b/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
@@ -56,12 +56,14 @@ public enum ErrorCode {
     MENU_CATEGORY_ORDER_CONFLICT("MC004", HttpStatus.CONFLICT, "메뉴 카테고리 순서가 충돌했습니다. 다시 시도해주세요."),
     MENU_CATEGORY_HAS_ITEMS(
             "MC005", HttpStatus.BAD_REQUEST, "메뉴 카테고리에 메뉴 아이템이 존재합니다. 먼저 메뉴 아이템을 삭제해주세요."),
+    MENU_CATEGORY_FORBIDDEN("MC006", HttpStatus.FORBIDDEN, "해당 메뉴 카테고리에 대한 권한이 없습니다."),
 
     // menuItem
     MENU_ITEM_NOT_FOUND("MI001", HttpStatus.NOT_FOUND, "메뉴 아이템이 없습니다"),
     INVALID_MENU_ITEM_ORDER("MI002", HttpStatus.BAD_REQUEST, "메뉴 순서가 유효하지 않습니다"),
     DUPLICATE_MENU_ITEM_NAME("MI003", HttpStatus.CONFLICT, "같은 카테고리에 같은 이름의 메뉴 아이템이 존재합니다"),
     MENU_ITEM_ORDER_CONFLICT("MI004", HttpStatus.CONFLICT, "메뉴 아이템 순서가 충돌했습니다. 다시 시도해주세요."),
+    MENU_ITEM_FORBIDDEN("MI005", HttpStatus.FORBIDDEN, "해당 메뉴 아이템에 대한 권한이 없습니다."),
 
     // cart
     CART_NOT_FOUND("CT001", HttpStatus.NOT_FOUND, "장바구니가 없습니다."),

--- a/src/main/java/com/project/baedalsodae/menu/common/StoreOwnershipValidator.java
+++ b/src/main/java/com/project/baedalsodae/menu/common/StoreOwnershipValidator.java
@@ -1,0 +1,27 @@
+package com.project.baedalsodae.menu.common;
+
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
+import com.project.baedalsodae.global.common.BusinessException;
+import com.project.baedalsodae.global.common.ErrorCode;
+import com.project.baedalsodae.store.entity.Store;
+import com.project.baedalsodae.user.entity.UserRole;
+import java.util.Objects;
+
+public class StoreOwnershipValidator {
+
+    private StoreOwnershipValidator() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static void verifyStoreOwnership(
+            Store store, UserDetailsImpl userDetails, ErrorCode errorCode) {
+        Objects.requireNonNull(store, "Store must not be null");
+        Objects.requireNonNull(userDetails, "UserDetails must not be null");
+        Objects.requireNonNull(errorCode, "ErrorCode must not be null");
+
+        if (userDetails.getUserRole() == UserRole.OWNER
+                && !store.getUserId().equals(userDetails.getUserId())) {
+            throw new BusinessException(errorCode);
+        }
+    }
+}

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -34,7 +34,7 @@ public class MenuCategoryController {
             @Valid @RequestBody MenuCategoryPutRequestDto request,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         MenuCategoryResponseDto response =
-                menuCategoryService.updateMenuCategory(menuCategoryId, request);
+                menuCategoryService.updateMenuCategory(menuCategoryId, request, userDetails);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_UPDATED, response));
     }
 
@@ -45,17 +45,17 @@ public class MenuCategoryController {
             @Valid @RequestBody MenuCategoryPatchRequestDto request,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         MenuCategoryResponseDto response =
-                menuCategoryService.updateMenuCategoryOrder(menuCategoryId, request);
+                menuCategoryService.updateMenuCategoryOrder(menuCategoryId, request, userDetails);
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.MENU_CATEGORY_ORDER_UPDATED, response));
     }
 
     @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @DeleteMapping("/{menuCategoryId}")
-        menuCategoryService.deleteMenuCategory(menuCategoryId);
     public ResponseEntity<ApiResponse<Void>> deleteMenuCategory(
             @PathVariable UUID menuCategoryId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        menuCategoryService.deleteMenuCategory(menuCategoryId, userDetails);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_DELETED, null));
     }
 
@@ -63,6 +63,8 @@ public class MenuCategoryController {
     public ResponseEntity<ApiResponse<List<MenuItemResponseDto>>> getMenuItem(
             @PathVariable UUID menuCategoryId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<MenuItemResponseDto> response =
+                menuItemService.getMenuItem(menuCategoryId, userDetails);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_LIST_FOUND, response));
     }
 
@@ -72,6 +74,8 @@ public class MenuCategoryController {
             @PathVariable UUID menuCategoryId,
             @Valid @RequestBody MenuItemPostRequestDto request,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        MenuItemResponseDto response =
+                menuItemService.createMenuItem(menuCategoryId, request, userDetails);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_CREATED, response));
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuCategoryController.java
@@ -1,5 +1,6 @@
 package com.project.baedalsodae.menu.controller;
 
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
 import com.project.baedalsodae.global.common.ApiResponse;
 import com.project.baedalsodae.global.common.SuccessCode;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
@@ -14,6 +15,8 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -24,42 +27,51 @@ public class MenuCategoryController {
     private final MenuCategoryService menuCategoryService;
     private final MenuItemService menuItemService;
 
+    @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @PutMapping("/{menuCategoryId}")
     public ResponseEntity<ApiResponse<MenuCategoryResponseDto>> updateMenuCategory(
             @PathVariable UUID menuCategoryId,
-            @Valid @RequestBody MenuCategoryPutRequestDto request) {
+            @Valid @RequestBody MenuCategoryPutRequestDto request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         MenuCategoryResponseDto response =
                 menuCategoryService.updateMenuCategory(menuCategoryId, request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_UPDATED, response));
     }
 
+    @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @PatchMapping("/{menuCategoryId}/orders")
     public ResponseEntity<ApiResponse<MenuCategoryResponseDto>> updateMenuCategoryOrder(
             @PathVariable UUID menuCategoryId,
-            @Valid @RequestBody MenuCategoryPatchRequestDto request) {
+            @Valid @RequestBody MenuCategoryPatchRequestDto request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         MenuCategoryResponseDto response =
                 menuCategoryService.updateMenuCategoryOrder(menuCategoryId, request);
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.MENU_CATEGORY_ORDER_UPDATED, response));
     }
 
+    @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @DeleteMapping("/{menuCategoryId}")
-    public ResponseEntity<ApiResponse<Void>> deleteMenuCategory(@PathVariable UUID menuCategoryId) {
         menuCategoryService.deleteMenuCategory(menuCategoryId);
+    public ResponseEntity<ApiResponse<Void>> deleteMenuCategory(
+            @PathVariable UUID menuCategoryId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_DELETED, null));
     }
 
     @GetMapping("/{menuCategoryId}/menu-items")
     public ResponseEntity<ApiResponse<List<MenuItemResponseDto>>> getMenuItem(
-            @PathVariable UUID menuCategoryId) {
-        List<MenuItemResponseDto> response = menuItemService.getMenuItem(menuCategoryId);
+            @PathVariable UUID menuCategoryId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_LIST_FOUND, response));
     }
 
+    @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @PostMapping("/{menuCategoryId}/menu-items")
     public ResponseEntity<ApiResponse<MenuItemResponseDto>> createMenuItem(
-            @PathVariable UUID menuCategoryId, @Valid @RequestBody MenuItemPostRequestDto request) {
-        MenuItemResponseDto response = menuItemService.createMenuItem(menuCategoryId, request);
+            @PathVariable UUID menuCategoryId,
+            @Valid @RequestBody MenuItemPostRequestDto request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_CREATED, response));
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
@@ -30,6 +30,8 @@ public class MenuItemController {
             @PathVariable UUID menuItemId,
             @Valid @RequestBody MenuItemPutRequestDto request,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        MenuItemResponseDto response =
+                menuItemService.updateMenuItem(menuItemId, request, userDetails);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_UPDATED, response));
     }
 
@@ -39,6 +41,8 @@ public class MenuItemController {
             @PathVariable UUID menuItemId,
             @Valid @RequestBody MenuItemPatchRequestDto request,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        MenuItemResponseDto response =
+                menuItemService.patchMenuItem(menuItemId, request, userDetails);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_UPDATED, response));
     }
 
@@ -48,6 +52,8 @@ public class MenuItemController {
             @PathVariable UUID menuItemId,
             @RequestParam @Validated @Positive Integer order,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        MenuItemResponseDto response =
+                menuItemService.updateMenuItemOrder(menuItemId, order, userDetails);
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.MENU_ITEM_ORDER_UPDATED, response));
     }
@@ -56,6 +62,7 @@ public class MenuItemController {
     @DeleteMapping("/{menuItemId}")
     public ResponseEntity<ApiResponse<Void>> deleteMenuItem(
             @PathVariable UUID menuItemId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        menuItemService.deleteMenuItem(menuItemId, userDetails);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_DELETED, null));
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
+++ b/src/main/java/com/project/baedalsodae/menu/controller/MenuItemController.java
@@ -1,5 +1,6 @@
 package com.project.baedalsodae.menu.controller;
 
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
 import com.project.baedalsodae.global.common.ApiResponse;
 import com.project.baedalsodae.global.common.SuccessCode;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
@@ -11,6 +12,8 @@ import jakarta.validation.constraints.Positive;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,31 +24,38 @@ public class MenuItemController {
 
     private final MenuItemService menuItemService;
 
+    @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @PutMapping("/{menuItemId}")
     public ResponseEntity<ApiResponse<MenuItemResponseDto>> updateMenuItem(
-            @PathVariable UUID menuItemId, @Valid @RequestBody MenuItemPutRequestDto request) {
-        MenuItemResponseDto response = menuItemService.updateMenuItem(menuItemId, request);
+            @PathVariable UUID menuItemId,
+            @Valid @RequestBody MenuItemPutRequestDto request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_UPDATED, response));
     }
 
+    @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @PatchMapping("/{menuItemId}")
     public ResponseEntity<ApiResponse<MenuItemResponseDto>> patchMenuItem(
-            @PathVariable UUID menuItemId, @RequestBody MenuItemPatchRequestDto request) {
-        MenuItemResponseDto response = menuItemService.patchMenuItem(menuItemId, request);
+            @PathVariable UUID menuItemId,
+            @Valid @RequestBody MenuItemPatchRequestDto request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_UPDATED, response));
     }
 
+    @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @PatchMapping("/{menuItemId}/orders")
     public ResponseEntity<ApiResponse<MenuItemResponseDto>> updateMenuItemOrder(
-            @PathVariable UUID menuItemId, @RequestParam @Validated @Positive Integer order) {
-        MenuItemResponseDto response = menuItemService.updateMenuItemOrder(menuItemId, order);
+            @PathVariable UUID menuItemId,
+            @RequestParam @Validated @Positive Integer order,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.MENU_ITEM_ORDER_UPDATED, response));
     }
 
+    @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @DeleteMapping("/{menuItemId}")
-    public ResponseEntity<ApiResponse<Void>> deleteMenuItem(@PathVariable UUID menuItemId) {
-        menuItemService.deleteMenuItem(menuItemId);
+    public ResponseEntity<ApiResponse<Void>> deleteMenuItem(
+            @PathVariable UUID menuItemId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_ITEM_DELETED, null));
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/dto/responseDto/item/MenuItemResponseDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/responseDto/item/MenuItemResponseDto.java
@@ -1,4 +1,3 @@
-
 package com.project.baedalsodae.menu.dto.responseDto.item;
 
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;

--- a/src/main/java/com/project/baedalsodae/menu/dto/responseDto/item/MenuItemResponseDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/responseDto/item/MenuItemResponseDto.java
@@ -1,7 +1,10 @@
+
 package com.project.baedalsodae.menu.dto.responseDto.item;
 
+import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
 import com.project.baedalsodae.menu.entity.MenuItem;
 import com.project.baedalsodae.menu.entity.enums.MenuStatus;
+import java.util.List;
 import java.util.UUID;
 
 public record MenuItemResponseDto(
@@ -12,9 +15,10 @@ public record MenuItemResponseDto(
         int orderNo,
         boolean isPopular,
         MenuStatus menuStatus,
-        UUID categoryId,
-        String categoryName) {
-    public static MenuItemResponseDto fromEntity(MenuItem item) {
+        MenuCategoryResponseDto category,
+        List<String> tagNames) {
+
+    public static MenuItemResponseDto fromEntity(MenuItem item, List<String> tagNames) {
         return new MenuItemResponseDto(
                 item.getId(),
                 item.getName(),
@@ -23,7 +27,11 @@ public record MenuItemResponseDto(
                 item.getOrderNo(),
                 item.isPopular(),
                 item.getMenuStatus(),
-                item.getMenuCategory().getId(),
-                item.getMenuCategory().getName());
+                MenuCategoryResponseDto.fromEntity(item.getMenuCategory()),
+                tagNames);
+    }
+
+    public static MenuItemResponseDto fromEntity(MenuItem item) {
+        return fromEntity(item, List.of());
     }
 }

--- a/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
+++ b/src/main/java/com/project/baedalsodae/menu/entity/MenuItem.java
@@ -1,5 +1,7 @@
 package com.project.baedalsodae.menu.entity;
 
+import com.project.baedalsodae.global.common.BusinessException;
+import com.project.baedalsodae.global.common.ErrorCode;
 import com.project.baedalsodae.global.common.entity.BaseAuditEntity;
 import com.project.baedalsodae.menu.common.Orderable;
 import com.project.baedalsodae.menu.entity.enums.MenuStatus;
@@ -111,6 +113,11 @@ public class MenuItem extends BaseAuditEntity implements Orderable {
 
     public void changeMenuCategory(MenuCategory category) {
         this.menuCategory = category;
+    }
+
+    public int getValidOrderNo() {
+        if (orderNo == null) throw new BusinessException(ErrorCode.INVALID_MENU_ITEM_ORDER);
+        return orderNo;
     }
 
     @Override

--- a/src/main/java/com/project/baedalsodae/menu/entity/enums/MenuStatus.java
+++ b/src/main/java/com/project/baedalsodae/menu/entity/enums/MenuStatus.java
@@ -15,4 +15,8 @@ public enum MenuStatus {
     MenuStatus(String description) {
         this.description = description;
     }
+
+    public boolean isPubliclyVisible() {
+        return this == AVAILABLE || this == SOLD_OUT;
+    }
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuCategoryService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuCategoryService.java
@@ -1,5 +1,6 @@
 package com.project.baedalsodae.menu.service;
 
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
@@ -9,15 +10,16 @@ import java.util.UUID;
 
 public interface MenuCategoryService {
 
-    MenuCategoryResponseDto createMenuCategory(UUID storeId, MenuCategoryPostRequestDto request);
+    MenuCategoryResponseDto createMenuCategory(
+            UUID storeId, MenuCategoryPostRequestDto request, UserDetailsImpl userDetails);
 
     MenuCategoryResponseDto updateMenuCategory(
-            UUID menuCategoryId, MenuCategoryPutRequestDto request);
+            UUID menuCategoryId, MenuCategoryPutRequestDto request, UserDetailsImpl userDetails);
 
-    void deleteMenuCategory(UUID menuCategoryId);
+    void deleteMenuCategory(UUID menuCategoryId, UserDetailsImpl userDetails);
 
     MenuCategoryResponseDto updateMenuCategoryOrder(
-            UUID menuCategoryId, MenuCategoryPatchRequestDto request);
+            UUID menuCategoryId, MenuCategoryPatchRequestDto request, UserDetailsImpl userDetails);
 
     List<MenuCategoryResponseDto> getMenuCategories(UUID storeId);
 

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
@@ -26,5 +26,5 @@ public interface MenuItemService {
     MenuItemResponseDto updateMenuItemOrder(
             UUID menuItemId, Integer order, UserDetailsImpl userDetails);
 
-    List<MenuItemResponseDto> getMenuItem(UUID menuCategoryId);
+    List<MenuItemResponseDto> getMenuItem(UUID menuCategoryId, UserDetailsImpl userDetails);
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/MenuItemService.java
@@ -1,5 +1,6 @@
 package com.project.baedalsodae.menu.service;
 
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
@@ -9,17 +10,21 @@ import java.util.UUID;
 
 public interface MenuItemService {
 
-    MenuItemResponseDto createMenuItem(UUID menuCategoryId, MenuItemPostRequestDto request);
+    MenuItemResponseDto createMenuItem(
+            UUID menuCategoryId, MenuItemPostRequestDto request, UserDetailsImpl userDetails);
 
-    MenuItemResponseDto updateMenuItem(UUID menuItemId, MenuItemPutRequestDto request);
+    MenuItemResponseDto updateMenuItem(
+            UUID menuItemId, MenuItemPutRequestDto request, UserDetailsImpl userDetails);
 
-    MenuItemResponseDto patchMenuItem(UUID menuItemId, MenuItemPatchRequestDto request);
+    MenuItemResponseDto patchMenuItem(
+            UUID menuItemId, MenuItemPatchRequestDto request, UserDetailsImpl userDetails);
 
-    void deleteMenuItem(UUID menuItemId);
+    void deleteMenuItem(UUID menuItemId, UserDetailsImpl userDetails);
 
     boolean isDuplicateMenuItemName(UUID storeId, String name);
 
-    MenuItemResponseDto updateMenuItemOrder(UUID menuItemId, Integer order);
+    MenuItemResponseDto updateMenuItemOrder(
+            UUID menuItemId, Integer order, UserDetailsImpl userDetails);
 
     List<MenuItemResponseDto> getMenuItem(UUID menuCategoryId);
 }

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuCategoryServiceImpl.java
@@ -1,8 +1,10 @@
 package com.project.baedalsodae.menu.service.impl;
 
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
 import com.project.baedalsodae.menu.common.OrderUtil;
+import com.project.baedalsodae.menu.common.StoreOwnershipValidator;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
@@ -29,9 +31,11 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
     @Override
     @Transactional
     public MenuCategoryResponseDto createMenuCategory(
-            UUID storeId, MenuCategoryPostRequestDto request) {
+            UUID storeId, MenuCategoryPostRequestDto request, UserDetailsImpl userDetails) {
 
         Store store = getStoreByStoreId(storeId);
+        StoreOwnershipValidator.verifyStoreOwnership(
+                store, userDetails, ErrorCode.MENU_CATEGORY_FORBIDDEN);
         if (existsByStoreIdAndNameAndDeletedIsFalse(storeId, request.name())) {
             throw new BusinessException(ErrorCode.DUPLICATE_MENU_CATEGORY_NAME);
         }
@@ -48,9 +52,11 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
     @Override
     @Transactional
     public MenuCategoryResponseDto updateMenuCategory(
-            UUID menuCategoryId, MenuCategoryPutRequestDto request) {
+            UUID menuCategoryId, MenuCategoryPutRequestDto request, UserDetailsImpl userDetails) {
 
         MenuCategory menuCategory = getMenuCategoryByMenuCategoryId(menuCategoryId);
+        StoreOwnershipValidator.verifyStoreOwnership(
+                menuCategory.getStore(), userDetails, ErrorCode.MENU_CATEGORY_FORBIDDEN);
         if (!menuCategory.getName().equals(request.name())
                 && existsByStoreIdAndNameAndDeletedIsFalse(
                         menuCategory.getStore().getId(), request.name())) {
@@ -62,9 +68,11 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
 
     @Override
     @Transactional
-    public void deleteMenuCategory(UUID menuCategoryId) {
+    public void deleteMenuCategory(UUID menuCategoryId, UserDetailsImpl userDetails) {
 
         MenuCategory menuCategory = getMenuCategoryByMenuCategoryId(menuCategoryId);
+        StoreOwnershipValidator.verifyStoreOwnership(
+                menuCategory.getStore(), userDetails, ErrorCode.MENU_CATEGORY_FORBIDDEN);
         if (menuCategory.hasItem()) throw new BusinessException(ErrorCode.MENU_CATEGORY_HAS_ITEMS);
 
         UUID storeId = menuCategory.getStore().getId();
@@ -72,14 +80,16 @@ public class MenuCategoryServiceImpl implements MenuCategoryService {
                 menuCategoryRepository.findAllByStoreIdAndDeletedIsFalseWithLock(storeId);
 
         OrderUtil.deleteAndShift(menuCategories, menuCategory);
-        menuCategory.softDelete(null); // / 토큰 기능 추가 시 수정 필요
+        menuCategory.softDelete(userDetails.getUserId());
     }
 
     @Override
     @Transactional
     public MenuCategoryResponseDto updateMenuCategoryOrder(
-            UUID menuCategoryId, MenuCategoryPatchRequestDto request) {
+            UUID menuCategoryId, MenuCategoryPatchRequestDto request, UserDetailsImpl userDetails) {
         MenuCategory menuCategory = getMenuCategoryByMenuCategoryId(menuCategoryId);
+        StoreOwnershipValidator.verifyStoreOwnership(
+                menuCategory.getStore(), userDetails, ErrorCode.MENU_CATEGORY_FORBIDDEN);
         Integer from = menuCategory.getOrderNo();
         if (from == null) {
             throw new BusinessException(ErrorCode.INVALID_MENU_CATEGORY_ORDER);

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -1,8 +1,10 @@
 package com.project.baedalsodae.menu.service.impl;
 
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
 import com.project.baedalsodae.menu.common.OrderUtil;
+import com.project.baedalsodae.menu.common.StoreOwnershipValidator;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPostRequestDto;
 import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
@@ -13,9 +15,8 @@ import com.project.baedalsodae.menu.repository.MenuCategoryRepository;
 import com.project.baedalsodae.menu.repository.MenuItemRepository;
 import com.project.baedalsodae.menu.service.MenuItemService;
 import com.project.baedalsodae.tag.service.TagMappingService;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import com.project.baedalsodae.user.entity.UserRole;
+import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -31,8 +32,11 @@ public class MenuItemServiceImpl implements MenuItemService {
 
     @Transactional
     @Override
-    public MenuItemResponseDto createMenuItem(UUID menuCategoryId, MenuItemPostRequestDto request) {
+    public MenuItemResponseDto createMenuItem(
+            UUID menuCategoryId, MenuItemPostRequestDto request, UserDetailsImpl userDetails) {
         MenuCategory category = getMenuCategoryByMenuCategoryId(menuCategoryId);
+        StoreOwnershipValidator.verifyStoreOwnership(
+                category.getStore(), userDetails, ErrorCode.MENU_ITEM_FORBIDDEN);
         UUID storeId = category.getStore().getId();
         if (existsByStoreIdAndNameAndDeletedIsFalse(storeId, request.name())) {
             throw new BusinessException(ErrorCode.DUPLICATE_MENU_ITEM_NAME);
@@ -58,11 +62,14 @@ public class MenuItemServiceImpl implements MenuItemService {
 
     @Transactional
     @Override
-    public MenuItemResponseDto updateMenuItem(UUID menuItemId, MenuItemPutRequestDto request) {
+    public MenuItemResponseDto updateMenuItem(
+            UUID menuItemId, MenuItemPutRequestDto request, UserDetailsImpl userDetails) {
         MenuItem item =
                 menuItemRepository
                         .findByIdAndDeletedIsFalse(menuItemId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
+        StoreOwnershipValidator.verifyStoreOwnership(
+                item.getMenuCategory().getStore(), userDetails, ErrorCode.MENU_ITEM_FORBIDDEN);
         MenuCategory category = getMenuCategoryByMenuCategoryId(request.categoryId());
 
         UUID storeId = category.getStore().getId();
@@ -84,11 +91,14 @@ public class MenuItemServiceImpl implements MenuItemService {
 
     @Transactional
     @Override
-    public MenuItemResponseDto patchMenuItem(UUID menuItemId, MenuItemPatchRequestDto request) {
+    public MenuItemResponseDto patchMenuItem(
+            UUID menuItemId, MenuItemPatchRequestDto request, UserDetailsImpl userDetails) {
         MenuItem item =
                 menuItemRepository
                         .findByIdAndDeletedIsFalse(menuItemId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
+        StoreOwnershipValidator.verifyStoreOwnership(
+                item.getMenuCategory().getStore(), userDetails, ErrorCode.MENU_ITEM_FORBIDDEN);
         UUID currentCategoryId = item.getMenuCategory().getId();
         MenuCategory category = getMenuCategoryByMenuCategoryId(currentCategoryId);
         UUID storeId = category.getStore().getId();
@@ -116,18 +126,20 @@ public class MenuItemServiceImpl implements MenuItemService {
 
     @Transactional
     @Override
-    public void deleteMenuItem(UUID menuItemId) {
+    public void deleteMenuItem(UUID menuItemId, UserDetailsImpl userDetails) {
         MenuItem item =
                 menuItemRepository
                         .findByIdAndDeletedIsFalse(menuItemId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
+        StoreOwnershipValidator.verifyStoreOwnership(
+                item.getMenuCategory().getStore(), userDetails, ErrorCode.MENU_ITEM_FORBIDDEN);
         UUID menuCategoryId = item.getMenuCategory().getId();
 
         List<MenuItem> menuItems =
                 menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalseWithLock(
                         menuCategoryId);
         OrderUtil.deleteAndShift(menuItems, item);
-        item.softDelete(null); // 토큰 기능 추가 시 수정 필요
+        item.softDelete(userDetails.getUserId());
     }
 
     @Override
@@ -137,15 +149,15 @@ public class MenuItemServiceImpl implements MenuItemService {
 
     @Transactional
     @Override
-    public MenuItemResponseDto updateMenuItemOrder(UUID menuItemId, Integer order) {
+    public MenuItemResponseDto updateMenuItemOrder(
+            UUID menuItemId, Integer order, UserDetailsImpl userDetails) {
         MenuItem item =
                 menuItemRepository
                         .findByIdAndDeletedIsFalse(menuItemId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.MENU_ITEM_NOT_FOUND));
-        Integer from = item.getOrderNo();
-        if (from == null) {
-            throw new BusinessException(ErrorCode.INVALID_MENU_ITEM_ORDER);
-        }
+        StoreOwnershipValidator.verifyStoreOwnership(
+                item.getMenuCategory().getStore(), userDetails, ErrorCode.MENU_ITEM_FORBIDDEN);
+        int from = item.getValidOrderNo();
         int to = order;
 
         if (from == to) {

--- a/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/menu/service/impl/MenuItemServiceImpl.java
@@ -176,11 +176,31 @@ public class MenuItemServiceImpl implements MenuItemService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<MenuItemResponseDto> getMenuItem(UUID menuCategoryId) {
-        List<MenuItem> menuItems =
+    public List<MenuItemResponseDto> getMenuItem(UUID menuCategoryId, UserDetailsImpl userDetails) {
+        List<MenuItem> allItems =
                 menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalse(menuCategoryId);
 
-        return menuItems.stream().map(MenuItemResponseDto::fromEntity).toList();
+        List<MenuItem> items = new ArrayList<>();
+        List<UUID> itemIds = new ArrayList<>();
+        for (MenuItem item : allItems) {
+            if (isVisibleTo(item, userDetails)) {
+                items.add(item);
+                itemIds.add(item.getId());
+            }
+        }
+        if (items.isEmpty()) return List.of();
+        Map<UUID, List<String>> tagMap = tagMappingService.getTagNamesByMenuItemIds(itemIds);
+        List<MenuItemResponseDto> responseDto = new ArrayList<>();
+        for (MenuItem item : items) {
+            List<String> tagNames = tagMap.getOrDefault(item.getId(), List.of());
+            responseDto.add(MenuItemResponseDto.fromEntity(item, tagNames));
+        }
+        return responseDto;
+    }
+
+    private boolean isVisibleTo(MenuItem item, UserDetailsImpl userDetails) {
+        if (item.getMenuStatus().isPubliclyVisible()) return true;
+        return userDetails != null && userDetails.getUserRole() != UserRole.CUSTOMER;
     }
 
     private boolean existsByStoreIdAndNameAndDeletedIsFalse(UUID storeId, String name) {

--- a/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
+++ b/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
@@ -98,10 +98,11 @@ public class StoreController {
     @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @PostMapping("/{storeId}/menu-categories")
     public ResponseEntity<ApiResponse<MenuCategoryResponseDto>> createMenuCategory(
-        MenuCategoryResponseDto response = menuCategoryService.createMenuCategory(storeId, request);
             @PathVariable UUID storeId,
             @RequestBody @Valid MenuCategoryPostRequestDto request,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        MenuCategoryResponseDto response =
+                menuCategoryService.createMenuCategory(storeId, request, userDetails);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_CREATED, response));
     }
 

--- a/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
+++ b/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
@@ -1,5 +1,6 @@
 package com.project.baedalsodae.store.controller;
 
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
 import com.project.baedalsodae.global.common.ApiResponse;
 import com.project.baedalsodae.global.common.SuccessCode;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPostRequestDto;
@@ -22,6 +23,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -96,8 +98,10 @@ public class StoreController {
     @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MANAGER')")
     @PostMapping("/{storeId}/menu-categories")
     public ResponseEntity<ApiResponse<MenuCategoryResponseDto>> createMenuCategory(
-            @PathVariable UUID storeId, @RequestBody @Valid MenuCategoryPostRequestDto request) {
         MenuCategoryResponseDto response = menuCategoryService.createMenuCategory(storeId, request);
+            @PathVariable UUID storeId,
+            @RequestBody @Valid MenuCategoryPostRequestDto request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.MENU_CATEGORY_CREATED, response));
     }
 

--- a/src/main/java/com/project/baedalsodae/tag/repository/TagMappingRepository.java
+++ b/src/main/java/com/project/baedalsodae/tag/repository/TagMappingRepository.java
@@ -1,6 +1,8 @@
 package com.project.baedalsodae.tag.repository;
 
 import com.project.baedalsodae.tag.entity.TagMapping;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -11,4 +13,14 @@ public interface TagMappingRepository extends JpaRepository<TagMapping, UUID> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM TagMapping tm WHERE tm.menuItem.id = :menuItemId")
     void deleteByMenuItemId(UUID menuItemId);
+
+    interface TagNameProjection {
+        UUID getMenuItemId();
+
+        String getTagName();
+    }
+
+    @Query(
+            "SELECT tm.menuItem.id AS menuItemId, tm.tag.name AS tagName FROM TagMapping tm WHERE tm.menuItem.id IN :menuItemIds ORDER BY tm.menuItem.id, tm.orderNo")
+    List<TagNameProjection> findTagDataByMenuItemIds(Collection<UUID> menuItemIds);
 }

--- a/src/main/java/com/project/baedalsodae/tag/service/Impl/TagMappingServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/Impl/TagMappingServiceImpl.java
@@ -4,10 +4,10 @@ import com.project.baedalsodae.menu.entity.MenuItem;
 import com.project.baedalsodae.tag.entity.Tag;
 import com.project.baedalsodae.tag.entity.TagMapping;
 import com.project.baedalsodae.tag.repository.TagMappingRepository;
+import com.project.baedalsodae.tag.repository.TagMappingRepository.TagNameProjection;
 import com.project.baedalsodae.tag.service.TagMappingService;
 import com.project.baedalsodae.tag.service.TagService;
 import java.util.*;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,9 +27,10 @@ public class TagMappingServiceImpl implements TagMappingService {
 
         tagService.createNewTagsIfNotExists(distinctNames);
 
-        Map<String, Tag> tagMap =
-                tagService.findAllByNames(distinctNames).stream()
-                        .collect(Collectors.toMap(Tag::getName, t -> t));
+        Map<String, Tag> tagMap = new HashMap<>();
+        for (Tag tag : tagService.findAllByNames(distinctNames)) {
+            tagMap.put(tag.getName(), tag);
+        }
 
         List<TagMapping> tagMappings = new ArrayList<>();
 
@@ -47,5 +48,17 @@ public class TagMappingServiceImpl implements TagMappingService {
     @Override
     public void deleteAllTagMappingByMenuItemId(UUID menuItemId) {
         tagMappingRepository.deleteByMenuItemId(menuItemId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<UUID, List<String>> getTagNamesByMenuItemIds(List<UUID> menuItemIds) {
+        if (menuItemIds.isEmpty()) return Map.of();
+        Map<UUID, List<String>> result = new HashMap<>();
+        for (TagNameProjection row : tagMappingRepository.findTagDataByMenuItemIds(menuItemIds)) {
+            result.computeIfAbsent(row.getMenuItemId(), k -> new ArrayList<>())
+                    .add(row.getTagName());
+        }
+        return result;
     }
 }

--- a/src/main/java/com/project/baedalsodae/tag/service/TagMappingService.java
+++ b/src/main/java/com/project/baedalsodae/tag/service/TagMappingService.java
@@ -2,6 +2,7 @@ package com.project.baedalsodae.tag.service;
 
 import com.project.baedalsodae.menu.entity.MenuItem;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface TagMappingService {
@@ -9,4 +10,6 @@ public interface TagMappingService {
     void createTagMappings(MenuItem menuItem, List<String> tagNames);
 
     void deleteAllTagMappingByMenuItemId(UUID menuItemId);
+
+    Map<UUID, List<String>> getTagNamesByMenuItemIds(List<UUID> menuItemIds);
 }

--- a/src/test/java/com/project/baedalsodae/menu/fixture/MenuCategoryMockFixture.java
+++ b/src/test/java/com/project/baedalsodae/menu/fixture/MenuCategoryMockFixture.java
@@ -51,6 +51,17 @@ public class MenuCategoryMockFixture {
         return new CategoryAndStoreFixture(category, store);
     }
 
+    public static MenuCategory createMockCategoryWithUnrelatedStore(
+            MenuCategoryRepository menuCategoryRepository, UUID menuCategoryId) {
+        MenuCategory category = mock(MenuCategory.class);
+        Store store = mock(Store.class);
+        given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
+                .willReturn(Optional.of(category));
+        given(category.getStore()).willReturn(store);
+        given(store.getUserId()).willReturn(UUID.randomUUID());
+        return category;
+    }
+
     public static MenuCategory createMockCategory(UUID categoryId, String categoryName) {
         MenuCategory category = mock(MenuCategory.class);
         given(category.getId()).willReturn(categoryId);

--- a/src/test/java/com/project/baedalsodae/menu/fixture/MenuItemMockFixture.java
+++ b/src/test/java/com/project/baedalsodae/menu/fixture/MenuItemMockFixture.java
@@ -1,18 +1,35 @@
 package com.project.baedalsodae.menu.fixture;
 
 import static com.project.baedalsodae.menu.fixture.MenuTestConstants.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 import com.project.baedalsodae.menu.entity.MenuCategory;
 import com.project.baedalsodae.menu.entity.MenuItem;
 import com.project.baedalsodae.menu.entity.enums.MenuStatus;
+import com.project.baedalsodae.menu.repository.MenuItemRepository;
+import com.project.baedalsodae.store.entity.Store;
+import java.util.Optional;
 import java.util.UUID;
 
 public class MenuItemMockFixture {
 
     private MenuItemMockFixture() {
         throw new AssertionError("Utility class should not be instantiated");
+    }
+
+    public static MenuItem createMockItemWithUnrelatedStore(
+            MenuItemRepository menuItemRepository, UUID menuItemId) {
+        MenuItem item = mock(MenuItem.class);
+        MenuCategory category = mock(MenuCategory.class);
+        Store store = mock(Store.class);
+        given(menuItemRepository.findByIdAndDeletedIsFalse(menuItemId))
+                .willReturn(Optional.of(item));
+        given(item.getMenuCategory()).willReturn(category);
+        given(category.getStore()).willReturn(store);
+        given(store.getUserId()).willReturn(UUID.randomUUID());
+        return item;
     }
 
     public static MenuItem createMockMenuItem(

--- a/src/test/java/com/project/baedalsodae/menu/fixture/MenuTestConstants.java
+++ b/src/test/java/com/project/baedalsodae/menu/fixture/MenuTestConstants.java
@@ -1,9 +1,33 @@
 package com.project.baedalsodae.menu.fixture;
 
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
+import com.project.baedalsodae.user.entity.UserRole;
+import java.util.UUID;
+
 public final class MenuTestConstants {
 
     private MenuTestConstants() {
         throw new AssertionError("Utility class should not be instantiated");
+    }
+
+    public static UserDetailsImpl createManagerUserDetails() {
+        return UserDetailsImpl.builder()
+                .userId(UUID.randomUUID())
+                .username(MANAGER_USERNAME)
+                .password(null)
+                .userRole(UserRole.MANAGER)
+                .isDeleted(false)
+                .build();
+    }
+
+    public static UserDetailsImpl createOwnerUserDetails(UUID ownerId) {
+        return UserDetailsImpl.builder()
+                .userId(ownerId)
+                .username(OWNER_USERNAME)
+                .password(null)
+                .userRole(UserRole.OWNER)
+                .isDeleted(false)
+                .build();
     }
 
     public static final String ERROR_CODE_FIELD = "errorCode";
@@ -13,6 +37,10 @@ public final class MenuTestConstants {
     public static final int SECOND_ORDER_NUMBER = 2;
     public static final int THIRD_ORDER_NUMBER = 3;
     public static final int EXISTING_MAX_ORDER_NUMBER = 2;
+
+    // USERNAME
+    public static final String OWNER_USERNAME = "ownerUser";
+    public static final String MANAGER_USERNAME = "managerUser";
 
     // MENU ITEM
     public static final String DEFAULT_MENU_ITEM_NAME = "후라이드치킨";
@@ -28,4 +56,8 @@ public final class MenuTestConstants {
     public static final String NEW_CATEGORY_NAME = "새 카테고리";
     public static final String DUPLICATE_CATEGORY_NAME = "중복이름";
     public static final String NEW_UNIQUE_CATEGORY_NAME = "신카테고리";
+
+    // TAG
+    public static final String TAG_1 = "치킨";
+    public static final String TAG_2 = "바삭";
 }

--- a/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/menu/service/MenuCategoryServiceImplTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
 import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
@@ -43,11 +44,17 @@ class MenuCategoryServiceImplTest {
 
     private UUID storeId;
     private UUID menuCategoryId;
+    private UUID ownerId;
+    private UserDetailsImpl managerUserDetails;
+    private UserDetailsImpl ownerUserDetails;
 
     @BeforeEach
     void setUp() {
         storeId = UUID.randomUUID();
         menuCategoryId = UUID.randomUUID();
+        ownerId = UUID.randomUUID();
+        managerUserDetails = createManagerUserDetails();
+        ownerUserDetails = createOwnerUserDetails(ownerId);
     }
 
     @Nested
@@ -64,9 +71,29 @@ class MenuCategoryServiceImplTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> menuCategoryService.createMenuCategory(storeId, request))
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.createMenuCategory(
+                                            storeId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.STORE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: OWNER가 본인 가게가 아니면 예외가 발생한다")
+        void createMenuCategory_fail_forbidden() {
+            // given
+            Store store = createMockStoreWithRepository(storeRepository, storeId);
+            given(store.getUserId()).willReturn(UUID.randomUUID());
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.createMenuCategory(
+                                            storeId, request, ownerUserDetails))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_FORBIDDEN);
         }
 
         @Test
@@ -80,7 +107,10 @@ class MenuCategoryServiceImplTest {
                     .willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> menuCategoryService.createMenuCategory(storeId, request))
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.createMenuCategory(
+                                            storeId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.DUPLICATE_MENU_CATEGORY_NAME);
@@ -101,7 +131,10 @@ class MenuCategoryServiceImplTest {
                     .willThrow(new DataIntegrityViolationException("order conflict"));
 
             // when & then
-            assertThatThrownBy(() -> menuCategoryService.createMenuCategory(storeId, request))
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.createMenuCategory(
+                                            storeId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_ORDER_CONFLICT);
@@ -123,7 +156,7 @@ class MenuCategoryServiceImplTest {
 
             // when
             MenuCategoryResponseDto result =
-                    menuCategoryService.createMenuCategory(storeId, request);
+                    menuCategoryService.createMenuCategory(storeId, request, managerUserDetails);
 
             // then
             assertThat(result.orderNo()).isEqualTo(FIRST_ORDER_NUMBER);
@@ -146,7 +179,7 @@ class MenuCategoryServiceImplTest {
 
             // when
             MenuCategoryResponseDto result =
-                    menuCategoryService.createMenuCategory(storeId, request);
+                    menuCategoryService.createMenuCategory(storeId, request, managerUserDetails);
 
             // then
             assertThat(result.name()).isEqualTo(DEFAULT_CATEGORY_NAME);
@@ -168,10 +201,29 @@ class MenuCategoryServiceImplTest {
 
             // when & then
             assertThatThrownBy(
-                            () -> menuCategoryService.updateMenuCategory(menuCategoryId, request))
+                            () ->
+                                    menuCategoryService.updateMenuCategory(
+                                            menuCategoryId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: OWNER가 본인 가게가 아니면 예외가 발생한다")
+        void updateMenuCategory_fail_forbidden() {
+            // given
+            MenuCategoryPutRequestDto request = createDefaultPutRequest();
+            createMockCategoryWithUnrelatedStore(menuCategoryRepository, menuCategoryId);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.updateMenuCategory(
+                                            menuCategoryId, request, ownerUserDetails))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_FORBIDDEN);
         }
 
         @Test
@@ -187,7 +239,9 @@ class MenuCategoryServiceImplTest {
 
             // when & then
             assertThatThrownBy(
-                            () -> menuCategoryService.updateMenuCategory(menuCategoryId, request))
+                            () ->
+                                    menuCategoryService.updateMenuCategory(
+                                            menuCategoryId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.DUPLICATE_MENU_CATEGORY_NAME);
@@ -204,7 +258,7 @@ class MenuCategoryServiceImplTest {
             given(category.getOrderNo()).willReturn(FIRST_ORDER_NUMBER);
 
             // when
-            menuCategoryService.updateMenuCategory(menuCategoryId, request);
+            menuCategoryService.updateMenuCategory(menuCategoryId, request, managerUserDetails);
 
             // then
             verify(menuCategoryRepository, never())
@@ -226,7 +280,7 @@ class MenuCategoryServiceImplTest {
             given(category.getOrderNo()).willReturn(FIRST_ORDER_NUMBER);
 
             // when
-            menuCategoryService.updateMenuCategory(menuCategoryId, request);
+            menuCategoryService.updateMenuCategory(menuCategoryId, request, managerUserDetails);
 
             // then
             verify(category).changeMenuCategoryName(NEW_CATEGORY_NAME);
@@ -269,10 +323,29 @@ class MenuCategoryServiceImplTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> menuCategoryService.deleteMenuCategory(menuCategoryId))
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.deleteMenuCategory(
+                                            menuCategoryId, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: OWNER가 본인 가게가 아니면 예외가 발생한다")
+        void deleteMenuCategory_fail_forbidden() {
+            // given
+            createMockCategoryWithUnrelatedStore(menuCategoryRepository, menuCategoryId);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.deleteMenuCategory(
+                                            menuCategoryId, ownerUserDetails))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_FORBIDDEN);
         }
 
         @Test
@@ -280,12 +353,17 @@ class MenuCategoryServiceImplTest {
         void deleteMenuCategory_fail_hasItems() {
             // given
             MenuCategory category = mock(MenuCategory.class);
+            Store store = mock(Store.class);
             given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
                     .willReturn(Optional.of(category));
+            given(category.getStore()).willReturn(store);
             given(category.hasItem()).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> menuCategoryService.deleteMenuCategory(menuCategoryId))
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.deleteMenuCategory(
+                                            menuCategoryId, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_HAS_ITEMS);
@@ -298,10 +376,10 @@ class MenuCategoryServiceImplTest {
             givenCategoriesForDeletion();
 
             // when
-            menuCategoryService.deleteMenuCategory(menuCategoryId);
+            menuCategoryService.deleteMenuCategory(menuCategoryId, managerUserDetails);
 
             // then
-            verify(targetCategory).softDelete(null);
+            verify(targetCategory).softDelete(managerUserDetails.getUserId());
             verify(category3).changeOrderNo(SECOND_ORDER_NUMBER);
             verify(category1, never()).changeOrderNo(any());
         }
@@ -321,8 +399,7 @@ class MenuCategoryServiceImplTest {
             given(category.getOrderNo()).willReturn(orderNo);
             given(category.getId()).willReturn(menuCategoryId);
             given(category.getName()).willReturn(DEFAULT_CATEGORY_NAME);
-            lenient().when(category.getStore()).thenReturn(store);
-            lenient().when(store.getId()).thenReturn(storeId);
+            given(category.getStore()).willReturn(store);
         }
 
         @Test
@@ -337,10 +414,27 @@ class MenuCategoryServiceImplTest {
             assertThatThrownBy(
                             () ->
                                     menuCategoryService.updateMenuCategoryOrder(
-                                            menuCategoryId, request))
+                                            menuCategoryId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: OWNER가 본인 가게가 아니면 예외가 발생한다")
+        void updateMenuCategoryOrder_fail_forbidden() {
+            // given
+            MenuCategoryPatchRequestDto request = createPatchRequest(THIRD_ORDER_NUMBER);
+            createMockCategoryWithUnrelatedStore(menuCategoryRepository, menuCategoryId);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    menuCategoryService.updateMenuCategoryOrder(
+                                            menuCategoryId, request, ownerUserDetails))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_FORBIDDEN);
         }
 
         @Test
@@ -349,15 +443,17 @@ class MenuCategoryServiceImplTest {
             // given
             MenuCategoryPatchRequestDto request = createPatchRequest(THIRD_ORDER_NUMBER);
             category = mock(MenuCategory.class);
+            Store store = mock(Store.class);
             given(menuCategoryRepository.findByIdAndDeletedIsFalse(menuCategoryId))
                     .willReturn(Optional.of(category));
+            given(category.getStore()).willReturn(store);
             given(category.getOrderNo()).willReturn(null);
 
             // when & then
             assertThatThrownBy(
                             () ->
                                     menuCategoryService.updateMenuCategoryOrder(
-                                            menuCategoryId, request))
+                                            menuCategoryId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.INVALID_MENU_CATEGORY_ORDER);
@@ -371,7 +467,8 @@ class MenuCategoryServiceImplTest {
             givenCategoryExistsWithOrder(SECOND_ORDER_NUMBER);
 
             // when
-            menuCategoryService.updateMenuCategoryOrder(menuCategoryId, request);
+            menuCategoryService.updateMenuCategoryOrder(
+                    menuCategoryId, request, managerUserDetails);
 
             // then
             verify(menuCategoryRepository, never())
@@ -386,13 +483,15 @@ class MenuCategoryServiceImplTest {
             MenuCategory category2 = mock(MenuCategory.class);
             MenuCategory category3 = mock(MenuCategory.class);
             givenCategoryExistsWithOrder(FIRST_ORDER_NUMBER);
+            given(category.getStore().getId()).willReturn(storeId);
             given(category2.getOrderNo()).willReturn(SECOND_ORDER_NUMBER);
             given(category3.getOrderNo()).willReturn(THIRD_ORDER_NUMBER);
             given(menuCategoryRepository.findAllByStoreIdAndDeletedIsFalseWithLock(storeId))
                     .willReturn(List.of(category, category2, category3));
 
             // when
-            menuCategoryService.updateMenuCategoryOrder(menuCategoryId, request);
+            menuCategoryService.updateMenuCategoryOrder(
+                    menuCategoryId, request, managerUserDetails);
 
             // then
             verify(category).changeOrderNo(THIRD_ORDER_NUMBER);

--- a/src/test/java/com/project/baedalsodae/menu/service/MenuItemServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/menu/service/MenuItemServiceImplTest.java
@@ -3,6 +3,8 @@ package com.project.baedalsodae.menu.service;
 import static com.project.baedalsodae.menu.fixture.MenuCategoryMockFixture.CategoryAndStoreFixture;
 import static com.project.baedalsodae.menu.fixture.MenuCategoryMockFixture.createCategoryAndStoreFixture;
 import static com.project.baedalsodae.menu.fixture.MenuCategoryMockFixture.createMockCategory;
+import static com.project.baedalsodae.menu.fixture.MenuCategoryMockFixture.createMockCategoryWithUnrelatedStore;
+import static com.project.baedalsodae.menu.fixture.MenuItemMockFixture.createMockItemWithUnrelatedStore;
 import static com.project.baedalsodae.menu.fixture.MenuItemMockFixture.createMockMenuItem;
 import static com.project.baedalsodae.menu.fixture.MenuItemRequestFixture.*;
 import static com.project.baedalsodae.menu.fixture.MenuTestConstants.*;
@@ -12,6 +14,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
 import com.project.baedalsodae.menu.dto.requestDto.item.*;
@@ -25,12 +28,10 @@ import com.project.baedalsodae.menu.service.impl.MenuItemServiceImpl;
 import com.project.baedalsodae.store.entity.Store;
 import com.project.baedalsodae.tag.service.TagMappingService;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -49,12 +50,18 @@ class MenuItemServiceImplTest {
     private UUID menuCategoryId;
     private UUID menuItemId;
     private UUID storeId;
+    private UUID ownerId;
+    private UserDetailsImpl managerUserDetails;
+    private UserDetailsImpl ownerUserDetails;
 
     @BeforeEach
     void setUp() {
         menuCategoryId = UUID.randomUUID();
         menuItemId = UUID.randomUUID();
         storeId = UUID.randomUUID();
+        ownerId = UUID.randomUUID();
+        managerUserDetails = createManagerUserDetails();
+        ownerUserDetails = createOwnerUserDetails(ownerId);
     }
 
     private void givenCategoryAndStoreExist() {
@@ -99,10 +106,28 @@ class MenuItemServiceImplTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> menuItemService.createMenuItem(menuCategoryId, request))
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.createMenuItem(
+                                            menuCategoryId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: OWNER가 본인 가게가 아니면 예외가 발생한다")
+        void createMenuItem_fail_forbidden() {
+            // given
+            createMockCategoryWithUnrelatedStore(menuCategoryRepository, menuCategoryId);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.createMenuItem(
+                                            menuCategoryId, request, ownerUserDetails))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_FORBIDDEN);
         }
 
         @Test
@@ -116,7 +141,10 @@ class MenuItemServiceImplTest {
                     .willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> menuItemService.createMenuItem(menuCategoryId, request))
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.createMenuItem(
+                                            menuCategoryId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.DUPLICATE_MENU_ITEM_NAME);
@@ -137,7 +165,10 @@ class MenuItemServiceImplTest {
                     .willThrow(new DataIntegrityViolationException("order conflict"));
 
             // when & then
-            assertThatThrownBy(() -> menuItemService.createMenuItem(menuCategoryId, request))
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.createMenuItem(
+                                            menuCategoryId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_ORDER_CONFLICT);
@@ -157,11 +188,12 @@ class MenuItemServiceImplTest {
             given(menuItemRepository.save(any(MenuItem.class))).willAnswer(i -> i.getArgument(0));
 
             // when
-            MenuItemResponseDto result = menuItemService.createMenuItem(menuCategoryId, request);
+            MenuItemResponseDto result =
+                    menuItemService.createMenuItem(menuCategoryId, request, managerUserDetails);
 
             // then
             assertThat(result.orderNo()).isEqualTo(FIRST_ORDER_NUMBER);
-            assertThat(result.categoryId()).isEqualTo(menuCategoryId);
+            assertThat(result.category().id()).isEqualTo(menuCategoryId);
         }
 
         @Test
@@ -178,17 +210,18 @@ class MenuItemServiceImplTest {
             given(menuItemRepository.save(any(MenuItem.class))).willAnswer(i -> i.getArgument(0));
 
             // when
-            MenuItemResponseDto result = menuItemService.createMenuItem(menuCategoryId, request);
+            MenuItemResponseDto result =
+                    menuItemService.createMenuItem(menuCategoryId, request, managerUserDetails);
 
             // then
             assertThat(result.name()).isEqualTo(DEFAULT_MENU_ITEM_NAME);
             assertThat(result.orderNo()).isEqualTo(EXISTING_MAX_ORDER_NUMBER + 1);
             assertThat(result.menuStatus()).isEqualTo(MenuStatus.AVAILABLE);
-            assertThat(result.categoryId()).isEqualTo(menuCategoryId);
-            assertThat(result.categoryName()).isEqualTo(DEFAULT_CATEGORY_NAME);
+            assertThat(result.category().id()).isEqualTo(menuCategoryId);
+            assertThat(result.category().name()).isEqualTo(DEFAULT_CATEGORY_NAME);
             verify(menuItemRepository).save(any(MenuItem.class));
             verify(tagMappingService)
-                    .createTagMappings(any(MenuItem.class), eq(List.of("치킨", "바삭")));
+                    .createTagMappings(any(MenuItem.class), eq(List.of(TAG_1, TAG_2)));
         }
     }
 
@@ -210,13 +243,11 @@ class MenuItemServiceImplTest {
             item = mock(MenuItem.class);
             newCategory = mock(MenuCategory.class);
             Store newStore = mock(Store.class);
-            UUID newStoreId = UUID.randomUUID();
             given(menuItemRepository.findByIdAndDeletedIsFalse(menuItemId))
                     .willReturn(Optional.of(item));
             given(menuCategoryRepository.findByIdAndDeletedIsFalse(newCategoryId))
                     .willReturn(Optional.of(newCategory));
             given(newCategory.getStore()).willReturn(newStore);
-            given(newStore.getId()).willReturn(newStoreId);
         }
 
         @Test
@@ -227,9 +258,27 @@ class MenuItemServiceImplTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> menuItemService.updateMenuItem(menuItemId, request))
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.updateMenuItem(
+                                            menuItemId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: OWNER가 본인 가게가 아니면 예외가 발생한다")
+        void updateMenuItem_fail_forbidden() {
+            // given
+            item = createMockItemWithUnrelatedStore(menuItemRepository, menuItemId);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.updateMenuItem(
+                                            menuItemId, request, ownerUserDetails))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_FORBIDDEN);
         }
 
         @Test
@@ -239,13 +288,20 @@ class MenuItemServiceImplTest {
             UUID newCategoryId = UUID.randomUUID();
             MenuItemPutRequestDto testRequest = aPutRequest().withCategoryId(newCategoryId).build();
             item = mock(MenuItem.class);
+            MenuCategory currentCategory = mock(MenuCategory.class);
+            Store currentStore = mock(Store.class);
             given(menuItemRepository.findByIdAndDeletedIsFalse(menuItemId))
                     .willReturn(Optional.of(item));
+            given(item.getMenuCategory()).willReturn(currentCategory);
+            given(currentCategory.getStore()).willReturn(currentStore);
             given(menuCategoryRepository.findByIdAndDeletedIsFalse(newCategoryId))
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> menuItemService.updateMenuItem(menuItemId, testRequest))
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.updateMenuItem(
+                                            menuItemId, testRequest, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.MENU_CATEGORY_NOT_FOUND);
@@ -258,6 +314,7 @@ class MenuItemServiceImplTest {
             UUID newCategoryId = request.categoryId();
             UUID newStoreId = UUID.randomUUID();
             givenItemAndNewCategoryExist(newCategoryId);
+            given(item.getMenuCategory()).willReturn(newCategory);
             given(item.getName()).willReturn(DEFAULT_MENU_ITEM_NAME);
             given(newCategory.getStore().getId()).willReturn(newStoreId);
             given(
@@ -266,7 +323,10 @@ class MenuItemServiceImplTest {
                     .willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> menuItemService.updateMenuItem(menuItemId, request))
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.updateMenuItem(
+                                            menuItemId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.DUPLICATE_MENU_ITEM_NAME);
@@ -294,7 +354,7 @@ class MenuItemServiceImplTest {
             givenMenuItemFields(item, FIRST_ORDER_NUMBER);
 
             // when
-            menuItemService.updateMenuItem(menuItemId, sameNameRequest);
+            menuItemService.updateMenuItem(menuItemId, sameNameRequest, managerUserDetails);
 
             // then
             verify(menuItemRepository, never())
@@ -319,7 +379,7 @@ class MenuItemServiceImplTest {
             givenMenuItemFields(item, FIRST_ORDER_NUMBER);
 
             // when
-            menuItemService.updateMenuItem(menuItemId, request);
+            menuItemService.updateMenuItem(menuItemId, request, managerUserDetails);
 
             // then
             verify(item)
@@ -331,7 +391,7 @@ class MenuItemServiceImplTest {
                             newCategory,
                             true);
             verify(tagMappingService).deleteAllTagMappingByMenuItemId(menuItemId);
-            verify(tagMappingService).createTagMappings(item, List.of("치킨"));
+            verify(tagMappingService).createTagMappings(item, List.of(TAG_1));
         }
     }
 
@@ -365,9 +425,28 @@ class MenuItemServiceImplTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> menuItemService.patchMenuItem(menuItemId, request))
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.patchMenuItem(
+                                            menuItemId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: OWNER가 본인 가게가 아니면 예외가 발생한다")
+        void patchMenuItem_fail_forbidden() {
+            // given
+            MenuItemPatchRequestDto request = createPatchRequestWithName("새이름");
+            item = createMockItemWithUnrelatedStore(menuItemRepository, menuItemId);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.patchMenuItem(
+                                            menuItemId, request, ownerUserDetails))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_FORBIDDEN);
         }
 
         @Test
@@ -381,7 +460,10 @@ class MenuItemServiceImplTest {
                     .willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> menuItemService.patchMenuItem(menuItemId, request))
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.patchMenuItem(
+                                            menuItemId, request, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.DUPLICATE_MENU_ITEM_NAME);
@@ -396,7 +478,7 @@ class MenuItemServiceImplTest {
             givenMenuItemFields(item, FIRST_ORDER_NUMBER);
 
             // when
-            menuItemService.patchMenuItem(menuItemId, request);
+            menuItemService.patchMenuItem(menuItemId, request, managerUserDetails);
 
             // then
             verify(item, never()).changeName(any());
@@ -417,7 +499,7 @@ class MenuItemServiceImplTest {
             givenMenuItemFields(item, FIRST_ORDER_NUMBER);
 
             // when
-            menuItemService.patchMenuItem(menuItemId, request);
+            menuItemService.patchMenuItem(menuItemId, request, managerUserDetails);
 
             // then
             verify(tagMappingService).deleteAllTagMappingByMenuItemId(menuItemId);
@@ -436,7 +518,7 @@ class MenuItemServiceImplTest {
             givenMenuItemFields(item, FIRST_ORDER_NUMBER);
 
             // when
-            menuItemService.patchMenuItem(menuItemId, request);
+            menuItemService.patchMenuItem(menuItemId, request, managerUserDetails);
 
             // then
             verify(item).changeMenuCategory(newCategory);
@@ -453,7 +535,7 @@ class MenuItemServiceImplTest {
             givenMenuItemFields(item, FIRST_ORDER_NUMBER);
 
             // when
-            menuItemService.patchMenuItem(menuItemId, request);
+            menuItemService.patchMenuItem(menuItemId, request, managerUserDetails);
 
             // then
             verify(item).changeName("새이름");
@@ -470,7 +552,9 @@ class MenuItemServiceImplTest {
 
         private void givenItemsForDeletion() {
             MenuCategory category = mock(MenuCategory.class);
+            Store store = mock(Store.class);
             given(category.getId()).willReturn(menuCategoryId);
+            given(category.getStore()).willReturn(store);
 
             item1 = mock(MenuItem.class);
             given(item1.getOrderNo()).willReturn(FIRST_ORDER_NUMBER);
@@ -498,9 +582,21 @@ class MenuItemServiceImplTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> menuItemService.deleteMenuItem(menuItemId))
+            assertThatThrownBy(() -> menuItemService.deleteMenuItem(menuItemId, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: OWNER가 본인 가게가 아니면 예외가 발생한다")
+        void deleteMenuItem_fail_forbidden() {
+            // given
+            createMockItemWithUnrelatedStore(menuItemRepository, menuItemId);
+
+            // when & then
+            assertThatThrownBy(() -> menuItemService.deleteMenuItem(menuItemId, ownerUserDetails))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_FORBIDDEN);
         }
 
         @Test
@@ -510,10 +606,10 @@ class MenuItemServiceImplTest {
             givenItemsForDeletion();
 
             // when
-            menuItemService.deleteMenuItem(menuItemId);
+            menuItemService.deleteMenuItem(menuItemId, managerUserDetails);
 
             // then
-            verify(targetItem).softDelete(null);
+            verify(targetItem).softDelete(managerUserDetails.getUserId());
             verify(item3).changeOrderNo(SECOND_ORDER_NUMBER);
             verify(item1, never()).changeOrderNo(any());
         }
@@ -528,11 +624,14 @@ class MenuItemServiceImplTest {
         private void givenItemExists(int orderNo) {
             item = mock(MenuItem.class);
             MenuCategory category = mock(MenuCategory.class);
+            Store store = mock(Store.class);
             given(menuItemRepository.findByIdAndDeletedIsFalse(menuItemId))
                     .willReturn(Optional.of(item));
             given(item.getMenuCategory()).willReturn(category);
+            given(item.getValidOrderNo()).willReturn(orderNo);
             given(category.getId()).willReturn(menuCategoryId);
             given(category.getName()).willReturn(DEFAULT_CATEGORY_NAME);
+            given(category.getStore()).willReturn(store);
             givenMenuItemFields(item, orderNo);
         }
 
@@ -547,9 +646,24 @@ class MenuItemServiceImplTest {
             assertThatThrownBy(
                             () ->
                                     menuItemService.updateMenuItemOrder(
-                                            menuItemId, THIRD_ORDER_NUMBER))
+                                            menuItemId, THIRD_ORDER_NUMBER, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: OWNER가 본인 가게가 아니면 예외가 발생한다")
+        void updateMenuItemOrder_fail_forbidden() {
+            // given
+            item = createMockItemWithUnrelatedStore(menuItemRepository, menuItemId);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    menuItemService.updateMenuItemOrder(
+                                            menuItemId, THIRD_ORDER_NUMBER, ownerUserDetails))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(ERROR_CODE_FIELD, ErrorCode.MENU_ITEM_FORBIDDEN);
         }
 
         @Test
@@ -557,15 +671,20 @@ class MenuItemServiceImplTest {
         void updateMenuItemOrder_fail_invalidOrder() {
             // given
             item = mock(MenuItem.class);
+            MenuCategory category = mock(MenuCategory.class);
+            Store store = mock(Store.class);
             given(menuItemRepository.findByIdAndDeletedIsFalse(menuItemId))
                     .willReturn(Optional.of(item));
-            given(item.getOrderNo()).willReturn(null);
+            given(item.getMenuCategory()).willReturn(category);
+            given(category.getStore()).willReturn(store);
+            given(item.getValidOrderNo())
+                    .willThrow(new BusinessException(ErrorCode.INVALID_MENU_ITEM_ORDER));
 
             // when & then
             assertThatThrownBy(
                             () ->
                                     menuItemService.updateMenuItemOrder(
-                                            menuItemId, THIRD_ORDER_NUMBER))
+                                            menuItemId, THIRD_ORDER_NUMBER, managerUserDetails))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue(
                             ERROR_CODE_FIELD, ErrorCode.INVALID_MENU_ITEM_ORDER);
@@ -578,7 +697,8 @@ class MenuItemServiceImplTest {
             givenItemExists(SECOND_ORDER_NUMBER);
 
             // when
-            menuItemService.updateMenuItemOrder(menuItemId, SECOND_ORDER_NUMBER);
+            menuItemService.updateMenuItemOrder(
+                    menuItemId, SECOND_ORDER_NUMBER, managerUserDetails);
 
             // then
             verify(menuItemRepository, never())
@@ -600,7 +720,7 @@ class MenuItemServiceImplTest {
                     .willReturn(List.of(item, item2, item3));
 
             // when
-            menuItemService.updateMenuItemOrder(menuItemId, THIRD_ORDER_NUMBER);
+            menuItemService.updateMenuItemOrder(menuItemId, THIRD_ORDER_NUMBER, managerUserDetails);
 
             // then
             verify(item).changeOrderNo(THIRD_ORDER_NUMBER);
@@ -621,20 +741,22 @@ class MenuItemServiceImplTest {
                     .willReturn(List.of());
 
             // when
-            List<MenuItemResponseDto> result = menuItemService.getMenuItem(menuCategoryId);
+            List<MenuItemResponseDto> result = menuItemService.getMenuItem(menuCategoryId, null);
 
             // then
             assertThat(result).isEmpty();
         }
 
         @Test
-        @DisplayName("성공: 카테고리에 속한 메뉴 아이템 목록을 orderNo 순으로 반환한다")
+        @DisplayName("성공: 카테고리에 속한 메뉴 아이템 목록을 orderNo 순으로 반환하고 태그를 포함한다")
         void getMenuItem_success() {
             // given
             MenuCategory category = createMockCategory(menuCategoryId, DEFAULT_CATEGORY_NAME);
+            UUID item1Id = UUID.randomUUID();
+            UUID item2Id = UUID.randomUUID();
             MenuItem item1 =
                     createMockMenuItem(
-                            UUID.randomUUID(),
+                            item1Id,
                             DEFAULT_MENU_ITEM_NAME,
                             DEFAULT_ITEM_DESCRIPTION,
                             DEFAULT_ITEM_PRICE,
@@ -644,7 +766,7 @@ class MenuItemServiceImplTest {
                             category);
             MenuItem item2 =
                     createMockMenuItem(
-                            UUID.randomUUID(),
+                            item2Id,
                             ALTERNATIVE_MENU_ITEM_NAME,
                             "달콤",
                             ALTERNATIVE_ITEM_PRICE,
@@ -654,18 +776,112 @@ class MenuItemServiceImplTest {
                             category);
             given(menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalse(menuCategoryId))
                     .willReturn(List.of(item1, item2));
+            given(tagMappingService.getTagNamesByMenuItemIds(any()))
+                    .willReturn(Map.of(item1Id, List.of(TAG_1, TAG_2)));
 
             // when
-            List<MenuItemResponseDto> result = menuItemService.getMenuItem(menuCategoryId);
+            List<MenuItemResponseDto> result =
+                    menuItemService.getMenuItem(menuCategoryId, managerUserDetails);
 
             // then
             assertThat(result).hasSize(2);
             assertThat(result.get(0).name()).isEqualTo(DEFAULT_MENU_ITEM_NAME);
             assertThat(result.get(0).orderNo()).isEqualTo(FIRST_ORDER_NUMBER);
             assertThat(result.get(0).menuStatus()).isEqualTo(MenuStatus.AVAILABLE);
-            assertThat(result.get(0).categoryId()).isEqualTo(menuCategoryId);
+            assertThat(result.get(0).category().id()).isEqualTo(menuCategoryId);
+            assertThat(result.get(0).tagNames()).containsExactly(TAG_1, TAG_2);
             assertThat(result.get(1).name()).isEqualTo(ALTERNATIVE_MENU_ITEM_NAME);
             assertThat(result.get(1).orderNo()).isEqualTo(SECOND_ORDER_NUMBER);
+            assertThat(result.get(1).tagNames()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("성공: 비인증 사용자에게는 AVAILABLE, SOLD_OUT 상태만 반환된다")
+        void getMenuItem_success_filtersByStatusForGuest() {
+            // given
+            MenuCategory category = createMockCategory(menuCategoryId, DEFAULT_CATEGORY_NAME);
+            MenuItem available =
+                    createMockMenuItem(
+                            UUID.randomUUID(),
+                            DEFAULT_MENU_ITEM_NAME,
+                            DEFAULT_ITEM_DESCRIPTION,
+                            DEFAULT_ITEM_PRICE,
+                            FIRST_ORDER_NUMBER,
+                            false,
+                            MenuStatus.AVAILABLE,
+                            category);
+            MenuItem soldOut =
+                    createMockMenuItem(
+                            UUID.randomUUID(),
+                            ALTERNATIVE_MENU_ITEM_NAME,
+                            "설명",
+                            ALTERNATIVE_ITEM_PRICE,
+                            SECOND_ORDER_NUMBER,
+                            false,
+                            MenuStatus.SOLD_OUT,
+                            category);
+            MenuItem preparing =
+                    createMockMenuItem(
+                            UUID.randomUUID(),
+                            "준비중메뉴",
+                            "설명",
+                            DEFAULT_ITEM_PRICE,
+                            THIRD_ORDER_NUMBER,
+                            false,
+                            MenuStatus.PREPARING,
+                            category);
+            given(menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalse(menuCategoryId))
+                    .willReturn(List.of(available, soldOut, preparing));
+            given(tagMappingService.getTagNamesByMenuItemIds(any())).willReturn(Map.of());
+
+            // when
+            List<MenuItemResponseDto> result = menuItemService.getMenuItem(menuCategoryId, null);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result)
+                    .extracting(MenuItemResponseDto::menuStatus)
+                    .containsExactly(MenuStatus.AVAILABLE, MenuStatus.SOLD_OUT);
+        }
+
+        @Test
+        @DisplayName("성공: MANAGER는 모든 상태의 메뉴 아이템을 조회할 수 있다")
+        void getMenuItem_success_managerSeesAllStatuses() {
+            // given
+            MenuCategory category = createMockCategory(menuCategoryId, DEFAULT_CATEGORY_NAME);
+            MenuItem available =
+                    createMockMenuItem(
+                            UUID.randomUUID(),
+                            DEFAULT_MENU_ITEM_NAME,
+                            DEFAULT_ITEM_DESCRIPTION,
+                            DEFAULT_ITEM_PRICE,
+                            FIRST_ORDER_NUMBER,
+                            false,
+                            MenuStatus.AVAILABLE,
+                            category);
+            MenuItem preparing =
+                    createMockMenuItem(
+                            UUID.randomUUID(),
+                            "준비중메뉴",
+                            "설명",
+                            DEFAULT_ITEM_PRICE,
+                            SECOND_ORDER_NUMBER,
+                            false,
+                            MenuStatus.PREPARING,
+                            category);
+            given(menuItemRepository.findAllByMenuCategoryIdAndIsDeletedIsFalse(menuCategoryId))
+                    .willReturn(List.of(available, preparing));
+            given(tagMappingService.getTagNamesByMenuItemIds(any())).willReturn(Map.of());
+
+            // when
+            List<MenuItemResponseDto> result =
+                    menuItemService.getMenuItem(menuCategoryId, managerUserDetails);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result)
+                    .extracting(MenuItemResponseDto::menuStatus)
+                    .containsExactly(MenuStatus.AVAILABLE, MenuStatus.PREPARING);
         }
     }
 


### PR DESCRIPTION
### 📌 관련 이슈
- close #106 

### 💡 작업 내용
- 메뉴/메뉴카테고리 API에 권한 검증 로직 적용
- 가게 소유자 검증(추가 및 서비스 로직에 연동
- 메뉴 조회를 권한별로 분리/정리
- 메뉴 아이템 응답 DTO에 태그 정보 반영 및 태그 배치 조회 로직 추가
- 권한 체크 관련 테스트 코드 보강

### 🔍 변경 이유
- 권한 별 처리

### 📝 리뷰 포인트 (선택)
- 권한 검증 흐름이 컨트롤러/서비스 전반에서 일관되게 적용됐는지
- 조회 권한 분리 과정에서 기존 동작 회귀가 없는지
- 태그 배치 조회/매핑 로직의 성능 및 예외 처리

### 🧠 기타 참고 사항
- 메뉴/메뉴카테고리 권한 체크 테스트 케이스를 함께 추가했습니다.