### PR TITLE
Feat/105 address api

### DIFF
--- a/src/main/java/com/project/baedalsodae/global/common/dto/AuditInfoResponse.java
+++ b/src/main/java/com/project/baedalsodae/global/common/dto/AuditInfoResponse.java
@@ -1,12 +1,11 @@
 package com.project.baedalsodae.global.common.dto;
 
+import static com.project.baedalsodae.global.common.util.TimeUtils.toLocalDateTime;
+
 import com.project.baedalsodae.global.common.entity.BaseAuditEntity;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
-
-import static com.project.baedalsodae.global.common.util.TimeUtils.toLocalDateTime;
 
 @Getter
 public class AuditInfoResponse {

--- a/src/main/java/com/project/baedalsodae/global/common/dto/AuditInfoResponse.java
+++ b/src/main/java/com/project/baedalsodae/global/common/dto/AuditInfoResponse.java
@@ -2,25 +2,28 @@ package com.project.baedalsodae.global.common.dto;
 
 import com.project.baedalsodae.global.common.entity.BaseAuditEntity;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
+
+import static com.project.baedalsodae.global.common.util.TimeUtils.toLocalDateTime;
 
 @Getter
 public class AuditInfoResponse {
     private final UUID createdBy;
-    private final Instant createdAt;
+    private final LocalDateTime createdAt;
     private final UUID updatedBy;
-    private final Instant updatedAt;
+    private final LocalDateTime updatedAt;
     private final UUID deletedBy;
-    private final Instant deletedAt;
+    private final LocalDateTime deletedAt;
 
     private AuditInfoResponse(BaseAuditEntity entity) {
         this.createdBy = entity.getCreatedBy();
-        this.createdAt = entity.getCreatedAt();
+        this.createdAt = toLocalDateTime(entity.getCreatedAt());
         this.updatedBy = entity.getUpdatedBy();
-        this.updatedAt = entity.getUpdatedAt();
+        this.updatedAt = toLocalDateTime(entity.getUpdatedAt());
         this.deletedBy = entity.getDeletedBy();
-        this.deletedAt = entity.getDeletedAt();
+        this.deletedAt = toLocalDateTime(entity.getDeletedAt());
     }
 
     public static AuditInfoResponse fromEntity(BaseAuditEntity entity) {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>배달소대 - 가게 등록 테스트</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <h2>🥔 가게 등록 테스트</h2>
+    <form id="storeForm">
+        <div class="input-group">
+            <label>X-User-Id (테스트용 UUID)</label>
+            <input type="text" id="userId" placeholder="예: 550e8400-e29b-41d4-a716-446655440000">
+        </div>
+
+        <hr>
+
+        <input type="text" id="storeName" placeholder="가게 이름" required>
+        <input type="text" id="storeCategoryId" placeholder="카테고리 UUID" required>
+        <input type="text" id="businessNumber" placeholder="사업자 번호 (000-00-00000)" required>
+        <input type="text" id="storePhone" placeholder="전화번호 (02-000-0000)" required>
+
+        <div class="address-section">
+            <div class="row">
+                <input type="text" id="postcode" placeholder="우편번호" readonly>
+                <button type="button" onclick="searchAddress()">주소 검색</button>
+            </div>
+            <input type="text" id="roadAddress" placeholder="도로명주소" readonly required>
+            <input type="text" id="detailAddress" placeholder="상세주소">
+        </div>
+
+        <textarea id="description" placeholder="가게 설명 (선택)"></textarea>
+
+        <div class="codes">
+            <input type="hidden" id="sidoCode">
+            <input type="hidden" id="sidoName">
+            <input type="hidden" id="sigunguCode">
+            <input type="hidden" id="sigunguName">
+            <input type="hidden" id="dongCode">
+            <input type="hidden" id="dongName">
+        </div>
+
+        <button type="submit" class="submit-btn">가게 등록하기</button>
+    </form>
+</div>
+
+<script src="//t1.kakaocdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/src/main/resources/static/script.js
+++ b/src/main/resources/static/script.js
@@ -1,0 +1,66 @@
+function searchAddress() {
+    new kakao.Postcode({
+        oncomplete: function(data) {
+            // 주소 필드 세팅
+            document.getElementById('postcode').value = data.zonecode;
+            document.getElementById('roadAddress').value = data.roadAddress;
+
+            // 감자님의 엔티티 구조를 위한 코드 추출
+            document.getElementById('sidoCode').value = data.bcode.substring(0, 2); // bcode 앞 2자리
+            document.getElementById('sidoName').value = data.sido;
+            document.getElementById('sigunguCode').value = data.sigunguCode;
+            document.getElementById('sigunguName').value = data.sigungu;
+            document.getElementById('dongCode').value = data.bcode; // 법정동 10자리 코드
+            document.getElementById('dongName').value = data.bname;
+
+            document.getElementById("detailAddress").focus();
+        }
+    }).open();
+}
+
+document.getElementById('storeForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+
+    const userId = document.getElementById('userId').value;
+
+    // CreateStoreRequest 구조 생성
+    const payload = {
+        storeCategoryId: document.getElementById('storeCategoryId').value,
+        storeName: document.getElementById('storeName').value,
+        businessNumber: document.getElementById('businessNumber').value,
+        storePhone: document.getElementById('storePhone').value,
+        description: document.getElementById('description').value,
+        address: {
+            sidoCode: document.getElementById('sidoCode').value,
+            sidoName: document.getElementById('sidoName').value,
+            sigunguCode: document.getElementById('sigunguCode').value,
+            sigunguName: document.getElementById('sigunguName').value,
+            dongCode: document.getElementById('dongCode').value,
+            dongName: document.getElementById('dongName').value,
+            roadAddress: document.getElementById('roadAddress').value,
+            detailAddress: document.getElementById('detailAddress').value
+        }
+    };
+
+    try {
+        const response = await fetch('/api/v1/stores', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-User-Id': userId || '00000000-0000-0000-0000-000000000000' // 빈값일 때 기본값
+            },
+            body: JSON.stringify(payload)
+        });
+
+        const result = await response.json();
+        if (response.ok) {
+            alert('가게 등록 성공! 🥔');
+            console.log(result);
+        } else {
+            alert('등록 실패: ' + result.message);
+        }
+    } catch (error) {
+        console.error('Error:', error);
+        alert('서버 연결 오류');
+    }
+});

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,0 +1,62 @@
+body {
+    font-family: 'Pretendard', sans-serif;
+    background: #f5f5f5;
+    display: flex;
+    justify-content: center;
+    padding: 50px;
+}
+.container {
+    background: white;
+    padding: 30px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    width: 450px;
+}
+h2 {
+    text-align: center;
+    color: #333;
+    margin-bottom: 25px;
+}
+input, textarea {
+    width: 100%;
+    padding: 12px;
+    margin-bottom: 12px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    box-sizing: border-box;
+}
+.row {
+    display: flex;
+    gap: 8px;
+}
+.row input { flex: 1; }
+button {
+    padding: 12px 20px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: bold;
+}
+button[type="button"] {
+    background: #333;
+    color: white;
+    margin-bottom: 12px;
+}
+.submit-btn {
+    width: 100%;
+    background: #ffaa00;
+    color: white;
+    font-size: 16px;
+    margin-top: 10px;
+}
+.submit-btn:hover { background: #e69900; }
+textarea {
+    height: 80px;
+    resize: none;
+}
+.input-group label {
+    display: block;
+    font-size: 12px;
+    color: #666;
+    margin-bottom: 4px;
+}


### PR DESCRIPTION
### 📌 관련 이슈
- close #105 

### 💡 작업 내용
- AuditInfoResponse의 Instant 타입을 LocalDateTime으로 변경
- 카카오 주소 API 연동 테스트를 위한 테스트 페이지(html/js/css) 구현
- 주소 검색 후 사용자/가게 주소 데이터 저장 흐름 테스트

### 🔍 변경 이유
- 가게 및 사용자 주소 정보를 받아오기 위해 카카오 주소 API 도입
- 카카오 주소 API 연동 시 주소 검색 및 반환 데이터 구조를 사전에 검증하기 위해 테스트 페이지를 추가

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)