### PR TITLE
Feat/108 jwt refreshtoken

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ def generated = 'src/main/generated'
 dependencies {
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.apache.commons:commons-pool2'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/project/baedalsodae/auth/config/AuthConfig.java
+++ b/src/main/java/com/project/baedalsodae/auth/config/AuthConfig.java
@@ -3,6 +3,7 @@ package com.project.baedalsodae.auth.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.baedalsodae.auth.security.JwtAuthorizationFilter;
 import com.project.baedalsodae.auth.security.JwtProvider;
+import com.project.baedalsodae.auth.security.util.TokenRedisUtil;
 import com.project.baedalsodae.global.common.ApiResponse;
 import com.project.baedalsodae.global.common.ErrorCode;
 import jakarta.servlet.http.HttpServletResponse;
@@ -32,6 +33,7 @@ public class AuthConfig {
 
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
+    private final TokenRedisUtil tokenRedisUtil;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
@@ -41,7 +43,7 @@ public class AuthConfig {
 
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
-        return new JwtAuthorizationFilter(jwtProvider, objectMapper);
+        return new JwtAuthorizationFilter(jwtProvider, objectMapper, tokenRedisUtil);
     }
 
     @Bean

--- a/src/main/java/com/project/baedalsodae/auth/config/AuthConfig.java
+++ b/src/main/java/com/project/baedalsodae/auth/config/AuthConfig.java
@@ -19,7 +19,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -31,7 +30,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class AuthConfig {
 
-    private final UserDetailsService userDetailsService;
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
 
@@ -43,7 +41,7 @@ public class AuthConfig {
 
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
-        return new JwtAuthorizationFilter(jwtProvider, userDetailsService, objectMapper);
+        return new JwtAuthorizationFilter(jwtProvider, objectMapper);
     }
 
     @Bean

--- a/src/main/java/com/project/baedalsodae/auth/controller/AuthController.java
+++ b/src/main/java/com/project/baedalsodae/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.project.baedalsodae.auth.controller;
 
 import com.project.baedalsodae.auth.dto.request.LoginRequest;
+import com.project.baedalsodae.auth.dto.request.ReissueRequest;
 import com.project.baedalsodae.auth.dto.request.SignupRequest;
 import com.project.baedalsodae.auth.dto.response.LoginResponse;
 import com.project.baedalsodae.auth.dto.response.SignupResponse;
@@ -9,6 +10,7 @@ import com.project.baedalsodae.global.common.ApiResponse;
 import com.project.baedalsodae.global.common.SuccessCode;
 import com.project.baedalsodae.user.dto.response.UserDetailResponse;
 import com.project.baedalsodae.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +25,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
 
     private final UserService userService;
     private final AuthService authService;
@@ -48,14 +52,25 @@ public class AuthController {
         LoginResponse response = authService.login(request);
 
         return ResponseEntity.ok()
-                .header("Authorization", response.getAccessToken())
+                .header(AUTHORIZATION_HEADER, response.getAccessToken())
                 .body(ApiResponse.success(SuccessCode.LOGIN_SUCCESS, response));
     }
 
     @PreAuthorize("permitAll()")
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<LoginResponse>> reissue(
+            @Valid @RequestBody ReissueRequest request) {
+        LoginResponse response = authService.reissue(request.refreshToken());
+
+        return ResponseEntity.ok()
+                .header(AUTHORIZATION_HEADER, response.getAccessToken())
+                .body(ApiResponse.success(SuccessCode.LOGIN_SUCCESS, response));
+    }
+
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout() {
-        return ResponseEntity.status(HttpStatus.OK)
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request) {
+        authService.logout(request.getHeader(AUTHORIZATION_HEADER));
+        return ResponseEntity.ok()
                 .body(ApiResponse.success(SuccessCode.LOGOUT_SUCCESS.getMessage()));
     }
 }

--- a/src/main/java/com/project/baedalsodae/auth/dto/request/ReissueRequest.java
+++ b/src/main/java/com/project/baedalsodae/auth/dto/request/ReissueRequest.java
@@ -2,7 +2,4 @@ package com.project.baedalsodae.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record ReissueRequest(
-    @NotBlank
-    String refreshToken
-) {}
+public record ReissueRequest(@NotBlank String refreshToken) {}

--- a/src/main/java/com/project/baedalsodae/auth/dto/request/ReissueRequest.java
+++ b/src/main/java/com/project/baedalsodae/auth/dto/request/ReissueRequest.java
@@ -1,0 +1,8 @@
+package com.project.baedalsodae.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueRequest(
+    @NotBlank
+    String refreshToken
+) {}

--- a/src/main/java/com/project/baedalsodae/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/project/baedalsodae/auth/dto/response/LoginResponse.java
@@ -1,15 +1,19 @@
 package com.project.baedalsodae.auth.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class LoginResponse {
 
-    private String accessToken;
+    private final String accessToken;
+    private final String refreshToken;
 
-    public static LoginResponse from(String accessToken) {
-        return new LoginResponse(accessToken);
+    public static LoginResponse from(String accessToken, String refreshToken) {
+        return new LoginResponse(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/project/baedalsodae/auth/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/baedalsodae/auth/security/JwtAuthorizationFilter.java
@@ -44,15 +44,10 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         String resolvedAccessToken = jwtProvider.resolveToken(request.getHeader("Authorization"));
 
         if (StringUtils.hasText(resolvedAccessToken)) {
-            if (tokenRedisUtil.isBlacklisted(resolvedAccessToken)) {
-                sendErrorResponse(response, ErrorCode.UNAUTHORIZED);
-                return;
-            }
-
             try {
                 Claims claims = jwtProvider.getClaims(resolvedAccessToken);
 
-                if (!jwtProvider.isAccessToken(claims)) {
+                if (tokenRedisUtil.isBlacklisted(resolvedAccessToken)) {
                     sendErrorResponse(response, ErrorCode.UNAUTHORIZED);
                     return;
                 }

--- a/src/main/java/com/project/baedalsodae/auth/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/baedalsodae/auth/security/JwtAuthorizationFilter.java
@@ -18,7 +18,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -27,7 +26,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-    private final UserDetailsService userDetailsService;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -46,8 +44,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(resolvedAccessToken)) {
             try {
                 Claims claims = jwtProvider.getClaims(resolvedAccessToken);
-                String username = claims.getSubject();
-                setAuthentication(username);
+                setAuthentication(claims);
             } catch (BusinessException e) {
                 sendErrorResponse(response, e.getErrorCode());
                 return;
@@ -60,16 +57,16 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private void setAuthentication(String username) {
+    private void setAuthentication(Claims claims) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        Authentication authentication = createAuthentication(username);
+        Authentication authentication = createAuthentication(claims);
 
         context.setAuthentication(authentication);
         SecurityContextHolder.setContext(context);
     }
 
-    private Authentication createAuthentication(String username) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+    private Authentication createAuthentication(Claims claims) {
+        UserDetails userDetails = UserDetailsImpl.from(claims);
         return new UsernamePasswordAuthenticationToken(
                 userDetails, null, userDetails.getAuthorities());
     }

--- a/src/main/java/com/project/baedalsodae/auth/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/baedalsodae/auth/security/JwtAuthorizationFilter.java
@@ -1,6 +1,7 @@
 package com.project.baedalsodae.auth.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.baedalsodae.auth.security.util.TokenRedisUtil;
 import com.project.baedalsodae.global.common.ApiResponse;
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
@@ -27,6 +28,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
+    private final TokenRedisUtil tokenRedisUtil;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
@@ -39,11 +41,22 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String resolvedAccessToken = jwtProvider.resolveToken(request);
+        String resolvedAccessToken = jwtProvider.resolveToken(request.getHeader("Authorization"));
 
         if (StringUtils.hasText(resolvedAccessToken)) {
+            if (tokenRedisUtil.isBlacklisted(resolvedAccessToken)) {
+                sendErrorResponse(response, ErrorCode.UNAUTHORIZED);
+                return;
+            }
+
             try {
                 Claims claims = jwtProvider.getClaims(resolvedAccessToken);
+
+                if (!jwtProvider.isAccessToken(claims)) {
+                    sendErrorResponse(response, ErrorCode.UNAUTHORIZED);
+                    return;
+                }
+
                 setAuthentication(claims);
             } catch (BusinessException e) {
                 sendErrorResponse(response, e.getErrorCode());

--- a/src/main/java/com/project/baedalsodae/auth/security/JwtProvider.java
+++ b/src/main/java/com/project/baedalsodae/auth/security/JwtProvider.java
@@ -2,18 +2,16 @@ package com.project.baedalsodae.auth.security;
 
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
-import com.project.baedalsodae.user.entity.UserRole;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.PostConstruct;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
-import java.util.UUID;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -21,18 +19,23 @@ import org.springframework.util.StringUtils;
 @Component
 public class JwtProvider {
 
-    private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
     private static final String USER_ID = "userId";
     private static final String USER_ROLE = "userRole";
     private static final String IS_DELETED = "isDeleted";
+    private static final String TOKEN_TYPE = "tokenType";
+    private static final String ACCESS_TYPE = "ACCESS";
+    private static final String REFRESH_TYPE = "REFRESH";
 
     @Value("${JWT_SECRET}")
     private String secretKey;
 
     @Value("${JWT_EXPIRATION}")
     private long jwtExpiration;
+
+    @Value("${JWT_REFRESH_EXPIRATION}")
+    private long jwtRefreshExpiration;
 
     private SecretKey jwtSecretKey;
 
@@ -41,15 +44,16 @@ public class JwtProvider {
         this.jwtSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
     }
 
-    public String createAccessToken(UUID id, String username, UserRole role, boolean isDeleted) {
+    public String createAccessToken(UserDetails userDetails) {
         Date now = new Date();
         Date expiration = new Date(now.getTime() + jwtExpiration);
         String newAccessToken =
                 Jwts.builder()
-                        .subject(username)
-                        .claim(USER_ID, id.toString())
-                        .claim(USER_ROLE, role.getRole())
-                        .claim(IS_DELETED, isDeleted)
+                        .subject(userDetails.getUsername())
+                        .claim(USER_ID, ((UserDetailsImpl) userDetails).getUserId().toString())
+                        .claim(USER_ROLE, ((UserDetailsImpl) userDetails).getUserRole().getRole())
+                        .claim(IS_DELETED, ((UserDetailsImpl) userDetails).isDeleted())
+                        .claim(TOKEN_TYPE, ACCESS_TYPE)
                         .expiration(expiration)
                         .issuedAt(now)
                         .signWith(jwtSecretKey, Jwts.SIG.HS256)
@@ -58,9 +62,20 @@ public class JwtProvider {
         return String.format("%s%s", BEARER_PREFIX, newAccessToken);
     }
 
-    public String resolveToken(HttpServletRequest request) {
-        String token = request.getHeader(AUTHORIZATION_HEADER);
+    public String createRefreshToken(String username) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + jwtRefreshExpiration);
 
+        return Jwts.builder()
+                .subject(username)
+                .claim(TOKEN_TYPE, REFRESH_TYPE)
+                .expiration(expiration)
+                .issuedAt(now)
+                .signWith(jwtSecretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public String resolveToken(String token) {
         if (!StringUtils.hasText(token) || !token.startsWith(BEARER_PREFIX)) {
             return null;
         }
@@ -84,5 +99,17 @@ public class JwtProvider {
         } catch (IllegalArgumentException e) {
             throw new BusinessException(ErrorCode.JWT_INVALID);
         }
+    }
+
+    public long getRemainingTime(String token) {
+        Claims claims = this.getClaims(token);
+        Date expiration = claims.getExpiration();
+        long now = new Date().getTime();
+
+        return Math.max(0, expiration.getTime() - now);
+    }
+
+    public boolean isAccessToken(Claims claims) {
+        return ACCESS_TYPE.equals(claims.get(TOKEN_TYPE));
     }
 }

--- a/src/main/java/com/project/baedalsodae/auth/security/UserDetailsImpl.java
+++ b/src/main/java/com/project/baedalsodae/auth/security/UserDetailsImpl.java
@@ -1,6 +1,5 @@
 package com.project.baedalsodae.auth.security;
 
-import com.project.baedalsodae.user.entity.User;
 import com.project.baedalsodae.user.entity.UserRole;
 import io.jsonwebtoken.Claims;
 import java.util.ArrayList;
@@ -24,7 +23,8 @@ public class UserDetailsImpl implements UserDetails {
 
     @Getter private final boolean isDeleted;
 
-    public static UserDetailsImpl from(UUID userId, String username, String password, UserRole userRole, boolean isDeleted) {
+    public static UserDetailsImpl from(
+            UUID userId, String username, String password, UserRole userRole, boolean isDeleted) {
         return UserDetailsImpl.builder()
                 .userId(userId)
                 .username(username)

--- a/src/main/java/com/project/baedalsodae/auth/security/UserDetailsImpl.java
+++ b/src/main/java/com/project/baedalsodae/auth/security/UserDetailsImpl.java
@@ -24,13 +24,13 @@ public class UserDetailsImpl implements UserDetails {
 
     @Getter private final boolean isDeleted;
 
-    public static UserDetailsImpl from(User user) {
+    public static UserDetailsImpl from(UUID userId, String username, String password, UserRole userRole, boolean isDeleted) {
         return UserDetailsImpl.builder()
-                .userId(user.getId())
-                .username(user.getUsername())
-                .password(user.getPassword())
-                .userRole(user.getRole())
-                .isDeleted(user.isDeleted())
+                .userId(userId)
+                .username(username)
+                .password(password)
+                .userRole(userRole)
+                .isDeleted(isDeleted)
                 .build();
     }
 

--- a/src/main/java/com/project/baedalsodae/auth/security/util/TokenRedisUtil.java
+++ b/src/main/java/com/project/baedalsodae/auth/security/util/TokenRedisUtil.java
@@ -15,12 +15,13 @@ public class TokenRedisUtil {
     private final StringRedisTemplate redisTemplate;
 
     public void saveRefreshToken(String username, String refreshToken, long expirationMillis) {
-        redisTemplate.opsForValue().set(
-                REFRESH_TOKEN_PREFIX + username,
-                refreshToken,
-                expirationMillis,
-                TimeUnit.MILLISECONDS
-        );
+        redisTemplate
+                .opsForValue()
+                .set(
+                        REFRESH_TOKEN_PREFIX + username,
+                        refreshToken,
+                        expirationMillis,
+                        TimeUnit.MILLISECONDS);
     }
 
     public String getRefreshToken(String username) {
@@ -36,12 +37,13 @@ public class TokenRedisUtil {
     }
 
     public void saveBlacklist(String accessToken, long expirationMillis) {
-        redisTemplate.opsForValue().set(
-                BLACKLIST_PREFIX + accessToken,
-                "logout",
-                expirationMillis,
-                TimeUnit.MILLISECONDS
-        );
+        redisTemplate
+                .opsForValue()
+                .set(
+                        BLACKLIST_PREFIX + accessToken,
+                        "logout",
+                        expirationMillis,
+                        TimeUnit.MILLISECONDS);
     }
 
     public boolean isBlacklisted(String accessToken) {

--- a/src/main/java/com/project/baedalsodae/auth/security/util/TokenRedisUtil.java
+++ b/src/main/java/com/project/baedalsodae/auth/security/util/TokenRedisUtil.java
@@ -1,0 +1,50 @@
+package com.project.baedalsodae.auth.security.util;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenRedisUtil {
+
+    private static final String REFRESH_TOKEN_PREFIX = "RefreshToken:";
+    private static final String BLACKLIST_PREFIX = "Blacklist:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void saveRefreshToken(String username, String refreshToken, long expirationMillis) {
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + username,
+                refreshToken,
+                expirationMillis,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public String getRefreshToken(String username) {
+        return redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + username);
+    }
+
+    public void deleteRefreshToken(String username) {
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + username);
+    }
+
+    public boolean hasValidateRefreshToken(String username) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(REFRESH_TOKEN_PREFIX + username));
+    }
+
+    public void saveBlacklist(String accessToken, long expirationMillis) {
+        redisTemplate.opsForValue().set(
+                BLACKLIST_PREFIX + accessToken,
+                "logout",
+                expirationMillis,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public boolean isBlacklisted(String accessToken) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken));
+    }
+}

--- a/src/main/java/com/project/baedalsodae/auth/service/AuthService.java
+++ b/src/main/java/com/project/baedalsodae/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.project.baedalsodae.auth.dto.request.LoginRequest;
 import com.project.baedalsodae.auth.dto.response.LoginResponse;
 import com.project.baedalsodae.auth.security.JwtProvider;
 import com.project.baedalsodae.auth.security.UserDetailsImpl;
+import com.project.baedalsodae.auth.security.util.TokenRedisUtil;
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,6 +21,8 @@ public class AuthService {
 
     private final AuthenticationManager authenticationManager;
     private final JwtProvider jwtProvider;
+    private final TokenRedisUtil tokenRedisUtil;
+    private final UserDetailsService userDetailsService;
 
     public LoginResponse login(LoginRequest request) {
         try {
@@ -28,16 +32,47 @@ public class AuthService {
                                     request.username(), request.password()));
 
             UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
-            String accessToken =
-                    jwtProvider.createAccessToken(
-                            userDetails.getUserId(),
-                            userDetails.getUsername(),
-                            userDetails.getUserRole(),
-                            userDetails.isDeleted());
 
-            return LoginResponse.from(accessToken);
+            return issue(userDetails);
         } catch (AuthenticationException e) {
             throw new BusinessException(ErrorCode.LOGIN_FAILED);
         }
+    }
+
+    public void logout(String accessToken) {
+        String resolvedAccessToken = jwtProvider.resolveToken(accessToken);
+
+        String username = jwtProvider.getClaims(resolvedAccessToken).getSubject();
+        long remainingTime = jwtProvider.getRemainingTime(resolvedAccessToken);
+
+        tokenRedisUtil.deleteRefreshToken(username);
+        tokenRedisUtil.saveBlacklist(resolvedAccessToken, remainingTime);
+    }
+
+    public LoginResponse reissue(String refreshToken) {
+        String username = jwtProvider.getClaims(refreshToken).getSubject();
+
+        if (!tokenRedisUtil.hasValidateRefreshToken(username)
+                || !refreshToken.equals(tokenRedisUtil.getRefreshToken(username))) {
+            tokenRedisUtil.deleteRefreshToken(username);
+            throw new BusinessException(ErrorCode.JWT_INVALID);
+        }
+
+        UserDetailsImpl userDetails = (UserDetailsImpl) userDetailsService.loadUserByUsername(username);
+
+        return issue(userDetails);
+    }
+
+    private LoginResponse issue(UserDetailsImpl userDetails) {
+        if (!userDetails.isEnabled()) {
+            tokenRedisUtil.deleteRefreshToken(userDetails.getUsername());
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        String newAccessToken = jwtProvider.createAccessToken(userDetails);
+        String newRefreshToken = jwtProvider.createRefreshToken(userDetails.getUsername());
+        tokenRedisUtil.saveRefreshToken(
+                userDetails.getUsername(), newRefreshToken, jwtProvider.getRemainingTime(newRefreshToken));
+
+        return LoginResponse.from(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/com/project/baedalsodae/auth/service/AuthService.java
+++ b/src/main/java/com/project/baedalsodae/auth/service/AuthService.java
@@ -58,7 +58,8 @@ public class AuthService {
             throw new BusinessException(ErrorCode.JWT_INVALID);
         }
 
-        UserDetailsImpl userDetails = (UserDetailsImpl) userDetailsService.loadUserByUsername(username);
+        UserDetailsImpl userDetails =
+                (UserDetailsImpl) userDetailsService.loadUserByUsername(username);
 
         return issue(userDetails);
     }
@@ -71,7 +72,9 @@ public class AuthService {
         String newAccessToken = jwtProvider.createAccessToken(userDetails);
         String newRefreshToken = jwtProvider.createRefreshToken(userDetails.getUsername());
         tokenRedisUtil.saveRefreshToken(
-                userDetails.getUsername(), newRefreshToken, jwtProvider.getRemainingTime(newRefreshToken));
+                userDetails.getUsername(),
+                newRefreshToken,
+                jwtProvider.getRemainingTime(newRefreshToken));
 
         return LoginResponse.from(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/com/project/baedalsodae/auth/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/auth/service/UserDetailsServiceImpl.java
@@ -26,6 +26,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
                                         new UsernameNotFoundException(
                                                 ErrorCode.USER_NOT_FOUND.getMessage()));
 
-        return UserDetailsImpl.from(user);
+        return UserDetailsImpl.from(user.getId(), user.getUsername(), user.getPassword(), user.getRole(), user.isDeleted());
     }
 }

--- a/src/main/java/com/project/baedalsodae/auth/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/auth/service/UserDetailsServiceImpl.java
@@ -26,6 +26,11 @@ public class UserDetailsServiceImpl implements UserDetailsService {
                                         new UsernameNotFoundException(
                                                 ErrorCode.USER_NOT_FOUND.getMessage()));
 
-        return UserDetailsImpl.from(user.getId(), user.getUsername(), user.getPassword(), user.getRole(), user.isDeleted());
+        return UserDetailsImpl.from(
+                user.getId(),
+                user.getUsername(),
+                user.getPassword(),
+                user.getRole(),
+                user.isDeleted());
     }
 }

--- a/src/main/java/com/project/baedalsodae/global/common/config/RedisConfig.java
+++ b/src/main/java/com/project/baedalsodae/global/common/config/RedisConfig.java
@@ -1,0 +1,89 @@
+package com.project.baedalsodae.global.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password:}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        if (password != null && !password.isEmpty()) {
+            config.setPassword(password);
+        }
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = createObjectMapper();
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofHours(1)) // 기본 만료 시간 1시간
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                .disableCachingNullValues(); // null 값은 캐싱하지 않음
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        ObjectMapper objectMapper = createObjectMapper();
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+
+        return template;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+
+    private ObjectMapper createObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/project/baedalsodae/global/common/config/RedisConfig.java
+++ b/src/main/java/com/project/baedalsodae/global/common/config/RedisConfig.java
@@ -45,16 +45,21 @@ public class RedisConfig {
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
         ObjectMapper objectMapper = createObjectMapper();
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
 
-        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofHours(1)) // 기본 만료 시간 1시간
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
-                .disableCachingNullValues(); // null 값은 캐싱하지 않음
+        RedisCacheConfiguration config =
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .entryTtl(Duration.ofHours(1)) // 기본 만료 시간 1시간
+                        .serializeKeysWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new StringRedisSerializer()))
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        serializer))
+                        .disableCachingNullValues(); // null 값은 캐싱하지 않음
 
-        return RedisCacheManager.RedisCacheManagerBuilder
-                .fromConnectionFactory(connectionFactory)
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory)
                 .cacheDefaults(config)
                 .build();
     }
@@ -65,7 +70,8 @@ public class RedisConfig {
         template.setConnectionFactory(connectionFactory);
 
         ObjectMapper objectMapper = createObjectMapper();
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
 
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(serializer);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,12 @@ spring:
     init:
       mode: never
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+
 server:
   port: 18082
 

--- a/src/test/java/com/project/baedalsodae/auth/controller/LoginLogoutControllerTest.java
+++ b/src/test/java/com/project/baedalsodae/auth/controller/LoginLogoutControllerTest.java
@@ -89,7 +89,7 @@ public class LoginLogoutControllerTest {
     @DisplayName("성공 - 유효한 리프레시 토큰으로 재발급 요청 시 200 OK를 반환한다")
     void reissueSuccess() throws Exception {
         // given
-        com.project.baedalsodae.auth.dto.request.ReissueRequest request = 
+        com.project.baedalsodae.auth.dto.request.ReissueRequest request =
                 new com.project.baedalsodae.auth.dto.request.ReissueRequest("valid-refresh-token");
         LoginResponse response = LoginResponse.from("Bearer new-access-token", "new-refresh-token");
         given(authService.reissue(any())).willReturn(response);
@@ -108,7 +108,7 @@ public class LoginLogoutControllerTest {
     @DisplayName("실패 - 리프레시 토큰이 비어있으면 400 Bad Request를 반환한다")
     void reissueFailEmptyToken() throws Exception {
         // given
-        com.project.baedalsodae.auth.dto.request.ReissueRequest request = 
+        com.project.baedalsodae.auth.dto.request.ReissueRequest request =
                 new com.project.baedalsodae.auth.dto.request.ReissueRequest("");
 
         // when & then

--- a/src/test/java/com/project/baedalsodae/auth/controller/LoginLogoutControllerTest.java
+++ b/src/test/java/com/project/baedalsodae/auth/controller/LoginLogoutControllerTest.java
@@ -12,6 +12,7 @@ import com.project.baedalsodae.auth.config.AuthConfig;
 import com.project.baedalsodae.auth.dto.request.LoginRequest;
 import com.project.baedalsodae.auth.dto.response.LoginResponse;
 import com.project.baedalsodae.auth.security.JwtProvider;
+import com.project.baedalsodae.auth.security.util.TokenRedisUtil;
 import com.project.baedalsodae.auth.service.AuthService;
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
@@ -45,6 +46,8 @@ public class LoginLogoutControllerTest {
 
     @MockitoBean private UserDetailsService userDetailsService;
 
+    @MockitoBean private TokenRedisUtil tokenRedisUtil;
+
     private final String CONTEXT_PATH = "/api/v1";
     private final String BASE_URL = CONTEXT_PATH + "/auth";
 
@@ -53,7 +56,7 @@ public class LoginLogoutControllerTest {
     void loginSuccess() throws Exception {
         // given
         LoginRequest request = new LoginRequest("tester123", "Password123!");
-        LoginResponse response = LoginResponse.from("Bearer mock-token");
+        LoginResponse response = LoginResponse.from("Bearer mock-token", "mock-refresh-token");
         given(authService.login(any())).willReturn(response);
 
         // when & then
@@ -83,10 +86,53 @@ public class LoginLogoutControllerTest {
     }
 
     @Test
+    @DisplayName("성공 - 유효한 리프레시 토큰으로 재발급 요청 시 200 OK를 반환한다")
+    void reissueSuccess() throws Exception {
+        // given
+        com.project.baedalsodae.auth.dto.request.ReissueRequest request = 
+                new com.project.baedalsodae.auth.dto.request.ReissueRequest("valid-refresh-token");
+        LoginResponse response = LoginResponse.from("Bearer new-access-token", "new-refresh-token");
+        given(authService.reissue(any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(
+                        post(BASE_URL + "/reissue")
+                                .contextPath(CONTEXT_PATH)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Authorization", "Bearer new-access-token"));
+    }
+
+    @Test
+    @DisplayName("실패 - 리프레시 토큰이 비어있으면 400 Bad Request를 반환한다")
+    void reissueFailEmptyToken() throws Exception {
+        // given
+        com.project.baedalsodae.auth.dto.request.ReissueRequest request = 
+                new com.project.baedalsodae.auth.dto.request.ReissueRequest("");
+
+        // when & then
+        mockMvc.perform(
+                        post(BASE_URL + "/reissue")
+                                .contextPath(CONTEXT_PATH)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("성공 - 인증된 사용자는 로그아웃할 수 있다")
     @WithMockUser(authorities = "ROLE_CUSTOMER")
     void logoutSuccess() throws Exception {
-        mockMvc.perform(post(BASE_URL + "/logout").contextPath(CONTEXT_PATH).with(csrf()))
+        // given
+        given(jwtProvider.resolveToken(any())).willReturn("mock-token");
+
+        // when & then
+        mockMvc.perform(
+                        post(BASE_URL + "/logout")
+                                .contextPath(CONTEXT_PATH)
+                                .header("Authorization", "Bearer mock-token")
+                                .with(csrf()))
                 .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/project/baedalsodae/auth/controller/SignupControllerTest.java
+++ b/src/test/java/com/project/baedalsodae/auth/controller/SignupControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.baedalsodae.auth.dto.request.SignupRequest;
 import com.project.baedalsodae.auth.security.JwtProvider;
+import com.project.baedalsodae.auth.security.util.TokenRedisUtil;
 import com.project.baedalsodae.auth.service.AuthService;
 import com.project.baedalsodae.global.common.SuccessCode;
 import com.project.baedalsodae.user.dto.response.UserDetailResponse;
@@ -42,6 +43,8 @@ public class SignupControllerTest {
     @MockitoBean private JwtProvider jwtProvider;
 
     @MockitoBean private UserDetailsService userDetailsService;
+
+    @MockitoBean private TokenRedisUtil tokenRedisUtil;
 
     private final String BASE_URL = "/auth";
 

--- a/src/test/java/com/project/baedalsodae/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/project/baedalsodae/auth/service/AuthServiceTest.java
@@ -1,0 +1,204 @@
+package com.project.baedalsodae.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.project.baedalsodae.auth.dto.request.LoginRequest;
+import com.project.baedalsodae.auth.dto.response.LoginResponse;
+import com.project.baedalsodae.auth.security.JwtProvider;
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
+import com.project.baedalsodae.auth.security.util.TokenRedisUtil;
+import com.project.baedalsodae.global.common.BusinessException;
+import com.project.baedalsodae.global.common.ErrorCode;
+import com.project.baedalsodae.user.entity.UserRole;
+import io.jsonwebtoken.Claims;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @InjectMocks private AuthService authService;
+
+    @Mock private AuthenticationManager authenticationManager;
+
+    @Mock private JwtProvider jwtProvider;
+
+    @Mock private TokenRedisUtil tokenRedisUtil;
+
+    @Mock private UserDetailsService userDetailsService;
+
+    @Nested
+    @DisplayName("로그인 테스트")
+    class Login {
+
+        @Test
+        @DisplayName("성공 - 올바른 정보로 로그인하면 토큰을 발급하고 Redis에 저장")
+        void login_Success() {
+            // given
+            String username = "tester123";
+            LoginRequest request = new LoginRequest(username, "Password123!");
+            UUID userId = UUID.randomUUID();
+
+            Authentication mockAuthentication = mock(Authentication.class);
+            UserDetailsImpl mockUserDetails = UserDetailsImpl.from(userId, username, null, UserRole.CUSTOMER, false);
+
+            given(authenticationManager.authenticate(any())).willReturn(mockAuthentication);
+            given(mockAuthentication.getPrincipal()).willReturn(mockUserDetails);
+            given(jwtProvider.createAccessToken(any())).willReturn("Bearer access-token");
+            given(jwtProvider.createRefreshToken(anyString())).willReturn("refresh-token");
+            given(jwtProvider.getRemainingTime(anyString())).willReturn(604800000L);
+
+            // when
+            LoginResponse response = authService.login(request);
+
+            // then
+            assertThat(response.getAccessToken()).isEqualTo("Bearer access-token");
+            assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
+
+            // 핵심 검증: Redis 저장 메서드가 호출되었는지 확인
+            verify(tokenRedisUtil, times(1)).saveRefreshToken(eq(username), eq("refresh-token"), anyLong());
+        }
+
+        @Test
+        @DisplayName("실패 - 잘못된 비밀번호로 로그인 시 BusinessException이 발생")
+        void login_Fail_BadCredentials() {
+            // given
+            LoginRequest request = new LoginRequest("tester123", "wrong-password");
+            given(authenticationManager.authenticate(any())).willThrow(new BadCredentialsException("Invalid password"));
+
+            // when & then
+            assertThatThrownBy(() -> authService.login(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LOGIN_FAILED);
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃 테스트")
+    class Logout {
+
+        @Test
+        @DisplayName("성공 - 로그아웃 시 Redis에서 Refresh Token을 삭제하고 Access Token을 블랙리스트에 등록")
+        void logout_Success() {
+            // given
+            String accessToken = "Bearer access-token";
+            String resolvedAccessToken = "access-token";
+            String username = "tester123";
+            long remainingTime = 1800000L; // 30분
+
+            Claims mockClaims = mock(Claims.class);
+
+            given(jwtProvider.resolveToken(accessToken)).willReturn(resolvedAccessToken);
+            given(jwtProvider.getClaims(resolvedAccessToken)).willReturn(mockClaims);
+            given(mockClaims.getSubject()).willReturn(username);
+            given(jwtProvider.getRemainingTime(resolvedAccessToken)).willReturn(remainingTime);
+
+            // when
+            authService.logout(accessToken);
+
+            // then
+            verify(tokenRedisUtil, times(1)).deleteRefreshToken(username);
+            verify(tokenRedisUtil, times(1)).saveBlacklist(resolvedAccessToken, remainingTime);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급 테스트")
+    class Reissue {
+
+        @Test
+        @DisplayName("성공 - 유효한 리프레시 토큰으로 재발급 시 새로운 토큰 세트를 반환하고 Redis를 갱신한다")
+        void reissue_Success() {
+            // given
+            String oldRefreshToken = "old-refresh-token";
+            String username = "tester123";
+
+            Claims mockClaims = mock(Claims.class);
+            UserDetailsImpl mockUserDetails = UserDetailsImpl.from(UUID.randomUUID(), username, null, UserRole.CUSTOMER, false);
+
+            given(jwtProvider.getClaims(oldRefreshToken)).willReturn(mockClaims);
+            given(mockClaims.getSubject()).willReturn(username);
+            given(tokenRedisUtil.hasValidateRefreshToken(username)).willReturn(true);
+            given(tokenRedisUtil.getRefreshToken(username)).willReturn(oldRefreshToken);
+            given(userDetailsService.loadUserByUsername(username)).willReturn(mockUserDetails);
+
+            given(jwtProvider.createAccessToken(any())).willReturn("Bearer new-access-token");
+            given(jwtProvider.createRefreshToken(username)).willReturn("new-refresh-token");
+            given(jwtProvider.getRemainingTime("new-refresh-token")).willReturn(604800000L);
+
+            // when
+            LoginResponse response = authService.reissue(oldRefreshToken);
+
+            // then
+            assertThat(response.getAccessToken()).isEqualTo("Bearer new-access-token");
+            assertThat(response.getRefreshToken()).isEqualTo("new-refresh-token");
+
+            verify(tokenRedisUtil, times(1)).saveRefreshToken(eq(username), eq("new-refresh-token"), anyLong());
+        }
+
+        @Test
+        @DisplayName("실패 - Redis에 저장된 토큰과 일치하지 않으면 세션을 삭제하고 예외를 던진다")
+        void reissue_Fail_TokenMismatch() {
+            // given
+            String stolenRefreshToken = "stolen-token";
+            String username = "tester123";
+            Claims mockClaims = mock(Claims.class);
+
+            given(jwtProvider.getClaims(stolenRefreshToken)).willReturn(mockClaims);
+            given(mockClaims.getSubject()).willReturn(username);
+            given(tokenRedisUtil.hasValidateRefreshToken(username)).willReturn(true);
+            given(tokenRedisUtil.getRefreshToken(username)).willReturn("different-token");
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(stolenRefreshToken))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.JWT_INVALID);
+
+            verify(tokenRedisUtil, times(1)).deleteRefreshToken(username);
+        }
+
+        @Test
+        @DisplayName("실패 - 계정이 비활성화된 상태에서 재발급 시도 시 세션을 삭제하고 예외를 던진다")
+        void reissue_Fail_UserDisabled() {
+            // given
+            String refreshToken = "valid-token";
+            String username = "tester123";
+            Claims mockClaims = mock(Claims.class);
+            UserDetailsImpl disabledUser = UserDetailsImpl.from(UUID.randomUUID(), username, null, UserRole.CUSTOMER, true);
+
+            given(jwtProvider.getClaims(refreshToken)).willReturn(mockClaims);
+            given(mockClaims.getSubject()).willReturn(username);
+            given(tokenRedisUtil.hasValidateRefreshToken(username)).willReturn(true);
+            given(tokenRedisUtil.getRefreshToken(username)).willReturn(refreshToken);
+            given(userDetailsService.loadUserByUsername(username)).willReturn(disabledUser);
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(refreshToken))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+            verify(tokenRedisUtil, times(1)).deleteRefreshToken(username);
+        }
+    }
+}

--- a/src/test/java/com/project/baedalsodae/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/project/baedalsodae/auth/service/AuthServiceTest.java
@@ -61,7 +61,8 @@ public class AuthServiceTest {
             UUID userId = UUID.randomUUID();
 
             Authentication mockAuthentication = mock(Authentication.class);
-            UserDetailsImpl mockUserDetails = UserDetailsImpl.from(userId, username, null, UserRole.CUSTOMER, false);
+            UserDetailsImpl mockUserDetails =
+                    UserDetailsImpl.from(userId, username, null, UserRole.CUSTOMER, false);
 
             given(authenticationManager.authenticate(any())).willReturn(mockAuthentication);
             given(mockAuthentication.getPrincipal()).willReturn(mockUserDetails);
@@ -77,7 +78,8 @@ public class AuthServiceTest {
             assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
 
             // 핵심 검증: Redis 저장 메서드가 호출되었는지 확인
-            verify(tokenRedisUtil, times(1)).saveRefreshToken(eq(username), eq("refresh-token"), anyLong());
+            verify(tokenRedisUtil, times(1))
+                    .saveRefreshToken(eq(username), eq("refresh-token"), anyLong());
         }
 
         @Test
@@ -85,7 +87,8 @@ public class AuthServiceTest {
         void login_Fail_BadCredentials() {
             // given
             LoginRequest request = new LoginRequest("tester123", "wrong-password");
-            given(authenticationManager.authenticate(any())).willThrow(new BadCredentialsException("Invalid password"));
+            given(authenticationManager.authenticate(any()))
+                    .willThrow(new BadCredentialsException("Invalid password"));
 
             // when & then
             assertThatThrownBy(() -> authService.login(request))
@@ -135,7 +138,9 @@ public class AuthServiceTest {
             String username = "tester123";
 
             Claims mockClaims = mock(Claims.class);
-            UserDetailsImpl mockUserDetails = UserDetailsImpl.from(UUID.randomUUID(), username, null, UserRole.CUSTOMER, false);
+            UserDetailsImpl mockUserDetails =
+                    UserDetailsImpl.from(
+                            UUID.randomUUID(), username, null, UserRole.CUSTOMER, false);
 
             given(jwtProvider.getClaims(oldRefreshToken)).willReturn(mockClaims);
             given(mockClaims.getSubject()).willReturn(username);
@@ -154,7 +159,8 @@ public class AuthServiceTest {
             assertThat(response.getAccessToken()).isEqualTo("Bearer new-access-token");
             assertThat(response.getRefreshToken()).isEqualTo("new-refresh-token");
 
-            verify(tokenRedisUtil, times(1)).saveRefreshToken(eq(username), eq("new-refresh-token"), anyLong());
+            verify(tokenRedisUtil, times(1))
+                    .saveRefreshToken(eq(username), eq("new-refresh-token"), anyLong());
         }
 
         @Test
@@ -185,7 +191,9 @@ public class AuthServiceTest {
             String refreshToken = "valid-token";
             String username = "tester123";
             Claims mockClaims = mock(Claims.class);
-            UserDetailsImpl disabledUser = UserDetailsImpl.from(UUID.randomUUID(), username, null, UserRole.CUSTOMER, true);
+            UserDetailsImpl disabledUser =
+                    UserDetailsImpl.from(
+                            UUID.randomUUID(), username, null, UserRole.CUSTOMER, true);
 
             given(jwtProvider.getClaims(refreshToken)).willReturn(mockClaims);
             given(mockClaims.getSubject()).willReturn(username);


### PR DESCRIPTION
### 📌 관련 이슈
- close #108 

### 💡 작업 내용

- redis 관련 설정 및 의존성 추가
- JwtProvide의 refreshToken 관련 기능 추가
  - refreshToken 발급, 토큰의 남은 유효시간 계산, 토큰 타입 확인 기능 구현

- JWT 기반 인증 기능 보강
  - 로그인: 아이디, 비밀번호 입력 후 로그인 시 accessToken, refreshToken을 클라이언트에게 발급

### 🔍 변경 이유
- 로그인 요청 시 DB 조회 빈도를 줄이고, 만료된 토큰을 자동으로 삭제하기 위해 redis를 사용
- 서버의 무상태성을 최대한 보장하면서도, 사용자의 로그인 상태를 유지하기 위해 refreshToken을 사용

### 📝 리뷰 포인트 (선택)
- redis 관련 의존성 및 설정 추가
  - application-local.yml 파일에 redis 관련 설정 추가
    - host, port에 관한 값이 있어야 RedisConfig의 설정을 적용 가능
  - RedisConfig 클래스 추가
    - redis 서버 연결
    - 문자열/JSON 객체 캐싱용 StringRedisTemplate, RedisTemplate 빈 등록 
    - Spring 어노테이션 기반 캐싱 관련 설정 추가

- refreshToken의 생명 주기
  - 최초 로그인 시 생성되어 redis에 저장
  - 설정한 유효기간이 만료되거나, 사용자가 로그아웃할 시 redis에서 삭제되면서 소멸

- refreshToken, redis 추가 후 로그인/로그아웃 기능의 변경사항
  - accessToken 재발급
     - 프론트엔드에서는 로그인 후 보유한 refreshToken을 서버에게 전달
     - 서버에서는 redis에 저장된 refreshToken이 유효한지 확인 후 accessToken, refreshToken을 재발급
     - 서버에서는 갱신된 accessToken과 refreshToken으로 클라이언트에게 응답
     (프론트엔드의 Interceptor에서는 accessToken 만료로 인한 401 상태코드를 수신할 때마다 토큰 재발급에 관한 API 요청을 백엔드 서버에게 전송)
  - 로그인: accessToken, refreshToken 생성 -> refreshToken은 redis에 저장
     - 로그인 성공 시 클라이언트에게 accessToken과 refreshToken을 반환
     - 로그인 시마다 redis에 저장된 refreshToken을 갱신 -> 마지막 로그인을 기준으로 재발급 가능한 accessToken을 결정
     - 생성된 refreshToken은 redis에 저장되어 자동 로그인을 수행하거나, 로그아웃 처리를 수행할 때 사용 가능
  - 로그아웃: 로그아웃 시 생성된 refreshToken 삭제 및 로그아웃한 사용자의 accessToken의 재사용 방지(블랙리스트)
     - refreshToken 삭제 시 클라이언트는 accessToken 재발급 불가 -> 자동 로그인 유지 불가능
     - 로그아웃한 사용자의 accessToken은 남은 유효기간이 만료될 때까지 블랙리스트로 redis에 등록되어, 로그아웃한 사용자의 accessToken이 만료되기 전에 악용되는 것을 방지

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)

- 배포 환경이 로컬 환경과는 차이가 있을 것 같아서 현재는 로컬에서 redis를 실행하기 위한 설정만 추가했습니다.
- 로컬에서 실행할 경우, 콘솔창에서 아래와 같이 docker 명령어를 입력해서 redis 이미지를 먼저 띄우신 후 Spring Boot 애플리케이션을 실행하면 정상적으로 실행됩니다.

```bash
docker run -d --name my-redis -p 6379:6379 redis
```