### PR TITLE
Docs/121menu storehours restdocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.5.11'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '6.25.0'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.project'
@@ -30,6 +31,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -37,6 +39,7 @@ repositories {
 }
 
 def generated = 'src/main/generated'
+def snippetsDir = file('build/generated-snippets')
 
 dependencies {
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
@@ -62,6 +65,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'com.h2database:h2'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -79,7 +84,8 @@ clean {
 
 tasks.named('test') {
     useJUnitPlatform()
-    
+    outputs.dir snippetsDir
+
     testLogging {
         events "passed", "skipped", "failed"
         showExceptions true
@@ -87,4 +93,10 @@ tasks.named('test') {
         showStackTraces true
         exceptionFormat "full"
     }
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
 }

--- a/src/docs/asciidoc/menu-category.adoc
+++ b/src/docs/asciidoc/menu-category.adoc
@@ -1,0 +1,120 @@
+= 메뉴 카테고리 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toc-title: 목차
+:toclevels: 2
+:sectlinks:
+
+[[menu-category-update]]
+== 메뉴 카테고리 이름 수정
+
+`PUT /menu-categories/{menuCategoryId}`
+
+권한: `OWNER`, `MANAGER`
+
+=== Path Parameters
+include::{snippets}/menu-category/update/path-parameters.adoc[]
+
+=== Request Fields
+include::{snippets}/menu-category/update/request-fields.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/menu-category/update/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/menu-category/update/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/menu-category/update/http-response.adoc[]
+
+---
+
+[[menu-category-update-order]]
+== 메뉴 카테고리 순서 변경
+
+`PATCH /menu-categories/{menuCategoryId}/orders`
+
+권한: `OWNER`, `MANAGER`
+
+=== Path Parameters
+include::{snippets}/menu-category/update-order/path-parameters.adoc[]
+
+=== Request Fields
+include::{snippets}/menu-category/update-order/request-fields.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/menu-category/update-order/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/menu-category/update-order/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/menu-category/update-order/http-response.adoc[]
+
+---
+
+[[menu-category-delete]]
+== 메뉴 카테고리 삭제
+
+`DELETE /menu-categories/{menuCategoryId}`
+
+권한: `OWNER`, `MANAGER`
+
+=== Path Parameters
+include::{snippets}/menu-category/delete/path-parameters.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/menu-category/delete/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/menu-category/delete/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/menu-category/delete/http-response.adoc[]
+
+---
+
+[[menu-category-get-menu-items]]
+== 카테고리별 메뉴 아이템 목록 조회
+
+`GET /menu-categories/{menuCategoryId}/menu-items`
+
+권한: 인증 불필요 (비공개 메뉴는 권한에 따라 필터링됨)
+
+=== Path Parameters
+include::{snippets}/menu-category/get-menu-items/path-parameters.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/menu-category/get-menu-items/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/menu-category/get-menu-items/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/menu-category/get-menu-items/http-response.adoc[]
+
+---
+
+[[menu-category-create-menu-item]]
+== 메뉴 아이템 생성
+
+`POST /menu-categories/{menuCategoryId}/menu-items`
+
+권한: `OWNER`, `MANAGER`
+
+=== Path Parameters
+include::{snippets}/menu-category/create-menu-item/path-parameters.adoc[]
+
+=== Request Fields
+include::{snippets}/menu-category/create-menu-item/request-fields.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/menu-category/create-menu-item/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/menu-category/create-menu-item/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/menu-category/create-menu-item/http-response.adoc[]

--- a/src/docs/asciidoc/menu-item.adoc
+++ b/src/docs/asciidoc/menu-item.adoc
@@ -1,0 +1,103 @@
+= 메뉴 아이템 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toc-title: 목차
+:toclevels: 2
+:sectlinks:
+
+[[menu-item-update]]
+== 메뉴 아이템 전체 수정 (PUT)
+
+`PUT /menu-items/{menuItemId}`
+
+권한: `OWNER`, `MANAGER`
+
+모든 필드를 교체합니다. 카테고리 이동이 가능합니다.
+
+=== Path Parameters
+include::{snippets}/menu-item/update/path-parameters.adoc[]
+
+=== Request Fields
+include::{snippets}/menu-item/update/request-fields.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/menu-item/update/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/menu-item/update/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/menu-item/update/http-response.adoc[]
+
+---
+
+[[menu-item-patch]]
+== 메뉴 아이템 부분 수정 (PATCH)
+
+`PATCH /menu-items/{menuItemId}`
+
+권한: `OWNER`, `MANAGER`
+
+전달된 필드만 변경합니다. 전달하지 않은 필드는 기존 값을 유지합니다.
+
+=== Path Parameters
+include::{snippets}/menu-item/patch/path-parameters.adoc[]
+
+=== Request Fields
+include::{snippets}/menu-item/patch/request-fields.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/menu-item/patch/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/menu-item/patch/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/menu-item/patch/http-response.adoc[]
+
+---
+
+[[menu-item-update-order]]
+== 메뉴 아이템 순서 변경
+
+`PATCH /menu-items/{menuItemId}/orders?order={order}`
+
+권한: `OWNER`, `MANAGER`
+
+=== Path Parameters
+include::{snippets}/menu-item/update-order/path-parameters.adoc[]
+
+=== Query Parameters
+include::{snippets}/menu-item/update-order/query-parameters.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/menu-item/update-order/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/menu-item/update-order/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/menu-item/update-order/http-response.adoc[]
+
+---
+
+[[menu-item-delete]]
+== 메뉴 아이템 삭제
+
+`DELETE /menu-items/{menuItemId}`
+
+권한: `OWNER`, `MANAGER`
+
+=== Path Parameters
+include::{snippets}/menu-item/delete/path-parameters.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/menu-item/delete/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/menu-item/delete/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/menu-item/delete/http-response.adoc[]

--- a/src/docs/asciidoc/store-hours.adoc
+++ b/src/docs/asciidoc/store-hours.adoc
@@ -1,0 +1,102 @@
+= 가게 영업시간 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toc-title: 목차
+:toclevels: 2
+:sectlinks:
+
+[[store-hours-create]]
+== 영업시간 등록
+
+`POST /stores/{storeId}/hours`
+
+권한: `OWNER`, `MANAGER`
+
+7개 요일 전체의 영업시간을 한 번에 등록합니다.
+
+=== Path Parameters
+include::{snippets}/store-hours/create/path-parameters.adoc[]
+
+=== Request Fields
+include::{snippets}/store-hours/create/request-fields.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/store-hours/create/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/store-hours/create/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/store-hours/create/http-response.adoc[]
+
+---
+
+[[store-hours-get]]
+== 영업시간 조회
+
+`GET /stores/{storeId}/hours`
+
+등록된 영업시간이 없으면 `data` 는 `null` 로 반환됩니다.
+
+=== Path Parameters
+include::{snippets}/store-hours/get/path-parameters.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/store-hours/get/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/store-hours/get/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/store-hours/get/http-response.adoc[]
+
+---
+
+[[store-hours-update]]
+== 영업시간 수정
+
+`PATCH /stores/{storeId}/hours`
+
+권한: `OWNER`, `MANAGER`
+
+7개 요일 전체를 교체합니다.
+
+=== Path Parameters
+include::{snippets}/store-hours/update/path-parameters.adoc[]
+
+=== Request Fields
+include::{snippets}/store-hours/update/request-fields.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/store-hours/update/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/store-hours/update/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/store-hours/update/http-response.adoc[]
+
+---
+
+[[store-hours-delete]]
+== 영업시간 삭제
+
+`DELETE /stores/{storeId}/hours`
+
+권한: `OWNER`, `MANAGER`
+
+가게의 모든 영업시간을 삭제합니다.
+
+=== Path Parameters
+include::{snippets}/store-hours/delete/path-parameters.adoc[]
+
+=== HTTP Request Example
+include::{snippets}/store-hours/delete/http-request.adoc[]
+
+=== Response Fields
+include::{snippets}/store-hours/delete/response-fields.adoc[]
+
+=== HTTP Response Example
+include::{snippets}/store-hours/delete/http-response.adoc[]

--- a/src/main/java/com/project/baedalsodae/global/component/DatabaseIndexInitializer.java
+++ b/src/main/java/com/project/baedalsodae/global/component/DatabaseIndexInitializer.java
@@ -3,10 +3,12 @@ package com.project.baedalsodae.global.component;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("!test")
 @RequiredArgsConstructor
 public class DatabaseIndexInitializer implements ApplicationRunner {
 

--- a/src/main/java/com/project/baedalsodae/menu/dto/responseDto/item/MenuItemResponseDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/responseDto/item/MenuItemResponseDto.java
@@ -1,4 +1,3 @@
-
 package com.project.baedalsodae.menu.dto.responseDto.item;
 
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;

--- a/src/main/java/com/project/baedalsodae/menu/dto/responseDto/item/MenuItemResponseDto.java
+++ b/src/main/java/com/project/baedalsodae/menu/dto/responseDto/item/MenuItemResponseDto.java
@@ -1,3 +1,4 @@
+
 package com.project.baedalsodae.menu.dto.responseDto.item;
 
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -17,3 +17,18 @@ spring:
   sql:
     init:
       mode: never
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+JWT_SECRET: test-secret-key
+JWT_EXPIRATION: 100000
+
+encryption:
+  aes:
+    key: test-aes-key-16b
+
+pg:
+  url: http://localhost:8089
+

--- a/src/test/java/com/project/baedalsodae/BaedalsodaeApplicationTests.java
+++ b/src/test/java/com/project/baedalsodae/BaedalsodaeApplicationTests.java
@@ -2,8 +2,10 @@ package com.project.baedalsodae;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BaedalsodaeApplicationTests {
 
     @Test

--- a/src/test/java/com/project/baedalsodae/menu/controller/MenuCategoryControllerTest.java
+++ b/src/test/java/com/project/baedalsodae/menu/controller/MenuCategoryControllerTest.java
@@ -1,0 +1,262 @@
+package com.project.baedalsodae.menu.controller;
+
+import static com.project.baedalsodae.menu.fixture.MenuTestConstants.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPatchRequestDto;
+import com.project.baedalsodae.menu.dto.requestDto.category.MenuCategoryPutRequestDto;
+import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPostRequestDto;
+import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
+import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
+import com.project.baedalsodae.menu.entity.enums.MenuStatus;
+import com.project.baedalsodae.menu.fixture.MenuCategoryRequestFixture;
+import com.project.baedalsodae.menu.fixture.MenuItemRequestFixture;
+import com.project.baedalsodae.menu.service.MenuCategoryService;
+import com.project.baedalsodae.menu.service.MenuItemService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MenuCategoryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+class MenuCategoryControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private MenuCategoryService menuCategoryService;
+
+    @MockitoBean private MenuItemService menuItemService;
+
+    private UUID menuCategoryId;
+    private UserDetailsImpl ownerDetails;
+    private MenuCategoryResponseDto categoryResponse;
+    private MenuItemResponseDto itemResponse;
+
+    @BeforeEach
+    void setUp() {
+        menuCategoryId = UUID.randomUUID();
+        ownerDetails = createOwnerUserDetails(UUID.randomUUID());
+
+        categoryResponse = new MenuCategoryResponseDto(menuCategoryId, DEFAULT_CATEGORY_NAME, 1);
+
+        MenuCategoryResponseDto categoryInItem =
+                new MenuCategoryResponseDto(menuCategoryId, DEFAULT_CATEGORY_NAME, 1);
+        itemResponse =
+                new MenuItemResponseDto(
+                        UUID.randomUUID(),
+                        DEFAULT_MENU_ITEM_NAME,
+                        DEFAULT_ITEM_DESCRIPTION,
+                        DEFAULT_ITEM_PRICE,
+                        1,
+                        false,
+                        MenuStatus.AVAILABLE,
+                        categoryInItem,
+                        List.of(TAG_1, TAG_2));
+    }
+
+    @Test
+    @DisplayName("성공 - 메뉴 카테고리 이름 수정")
+    void updateMenuCategory_success() throws Exception {
+        MenuCategoryPutRequestDto request = MenuCategoryRequestFixture.createDefaultPutRequest();
+        given(menuCategoryService.updateMenuCategory(eq(menuCategoryId), any(), any()))
+                .willReturn(categoryResponse);
+
+        mockMvc.perform(
+                        put("/menu-categories/{menuCategoryId}", menuCategoryId)
+                                .with(user(ownerDetails))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value(DEFAULT_CATEGORY_NAME))
+                .andDo(
+                        document(
+                                "menu-category/update",
+                                pathParameters(
+                                        parameterWithName("menuCategoryId")
+                                                .description("메뉴 카테고리 ID")),
+                                requestFields(fieldWithPath("name").description("변경할 카테고리 이름")),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data.id").description("카테고리 ID"),
+                                        fieldWithPath("data.name").description("카테고리 이름"),
+                                        fieldWithPath("data.orderNo").description("카테고리 정렬 순서"))));
+    }
+
+    @Test
+    @DisplayName("성공 - 메뉴 카테고리 순서 변경")
+    void updateMenuCategoryOrder_success() throws Exception {
+        MenuCategoryPatchRequestDto request = MenuCategoryRequestFixture.createPatchRequest(2);
+        given(menuCategoryService.updateMenuCategoryOrder(eq(menuCategoryId), any(), any()))
+                .willReturn(categoryResponse);
+
+        mockMvc.perform(
+                        patch("/menu-categories/{menuCategoryId}/orders", menuCategoryId)
+                                .with(user(ownerDetails))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "menu-category/update-order",
+                                pathParameters(
+                                        parameterWithName("menuCategoryId")
+                                                .description("메뉴 카테고리 ID")),
+                                requestFields(
+                                        fieldWithPath("orderNo").description("변경할 정렬 순서 (1 이상)")),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data.id").description("카테고리 ID"),
+                                        fieldWithPath("data.name").description("카테고리 이름"),
+                                        fieldWithPath("data.orderNo").description("카테고리 정렬 순서"))));
+    }
+
+    @Test
+    @DisplayName("성공 - 메뉴 카테고리 삭제")
+    void deleteMenuCategory_success() throws Exception {
+        willDoNothing().given(menuCategoryService).deleteMenuCategory(eq(menuCategoryId), any());
+
+        mockMvc.perform(
+                        delete("/menu-categories/{menuCategoryId}", menuCategoryId)
+                                .with(user(ownerDetails)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "menu-category/delete",
+                                pathParameters(
+                                        parameterWithName("menuCategoryId")
+                                                .description("메뉴 카테고리 ID")),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data")
+                                                .description("응답 데이터 (없음)")
+                                                .optional())));
+    }
+
+    @Test
+    @DisplayName("성공 - 메뉴 카테고리별 메뉴 아이템 목록 조회")
+    void getMenuItems_success() throws Exception {
+        given(menuItemService.getMenuItem(eq(menuCategoryId), any()))
+                .willReturn(List.of(itemResponse));
+
+        mockMvc.perform(
+                        get("/menu-categories/{menuCategoryId}/menu-items", menuCategoryId)
+                                .with(user(ownerDetails)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "menu-category/get-menu-items",
+                                pathParameters(
+                                        parameterWithName("menuCategoryId")
+                                                .description("메뉴 카테고리 ID")),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data[].id").description("메뉴 아이템 ID"),
+                                        fieldWithPath("data[].name").description("메뉴 이름"),
+                                        fieldWithPath("data[].description").description("메뉴 설명"),
+                                        fieldWithPath("data[].price").description("가격"),
+                                        fieldWithPath("data[].orderNo").description("정렬 순서"),
+                                        fieldWithPath("data[].isPopular").description("인기 메뉴 여부"),
+                                        fieldWithPath("data[].menuStatus")
+                                                .description(
+                                                        "메뉴 상태 (`AVAILABLE`, `SOLD_OUT`, `HIDDEN`)"),
+                                        fieldWithPath("data[].category.id").description("카테고리 ID"),
+                                        fieldWithPath("data[].category.name")
+                                                .description("카테고리 이름"),
+                                        fieldWithPath("data[].category.orderNo")
+                                                .description("카테고리 정렬 순서"),
+                                        fieldWithPath("data[].tagNames").description("태그 목록"))));
+    }
+
+    @Test
+    @DisplayName("성공 - 메뉴 아이템 생성")
+    void createMenuItem_success() throws Exception {
+        MenuItemPostRequestDto request = MenuItemRequestFixture.createDefaultPostRequest();
+        given(menuItemService.createMenuItem(eq(menuCategoryId), any(), any()))
+                .willReturn(itemResponse);
+
+        mockMvc.perform(
+                        post("/menu-categories/{menuCategoryId}/menu-items", menuCategoryId)
+                                .with(user(ownerDetails))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "menu-category/create-menu-item",
+                                pathParameters(
+                                        parameterWithName("menuCategoryId")
+                                                .description("메뉴 카테고리 ID")),
+                                requestFields(
+                                        fieldWithPath("name").description("메뉴 이름"),
+                                        fieldWithPath("description")
+                                                .description("메뉴 설명")
+                                                .optional(),
+                                        fieldWithPath("price").description("가격"),
+                                        fieldWithPath("isPopular").description("인기 메뉴 여부"),
+                                        fieldWithPath("menuStatus")
+                                                .description(
+                                                        "메뉴 상태 (`AVAILABLE`, `SOLD_OUT`, `HIDDEN`)"),
+                                        fieldWithPath("tagNames").description("태그 목록").optional()),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data.id").description("메뉴 아이템 ID"),
+                                        fieldWithPath("data.name").description("메뉴 이름"),
+                                        fieldWithPath("data.description").description("메뉴 설명"),
+                                        fieldWithPath("data.price").description("가격"),
+                                        fieldWithPath("data.orderNo").description("정렬 순서"),
+                                        fieldWithPath("data.isPopular").description("인기 메뉴 여부"),
+                                        fieldWithPath("data.menuStatus")
+                                                .description(
+                                                        "메뉴 상태 (`AVAILABLE`, `SOLD_OUT`, `HIDDEN`)"),
+                                        fieldWithPath("data.category.id").description("카테고리 ID"),
+                                        fieldWithPath("data.category.name").description("카테고리 이름"),
+                                        fieldWithPath("data.category.orderNo")
+                                                .description("카테고리 정렬 순서"),
+                                        fieldWithPath("data.tagNames").description("태그 목록"))));
+    }
+}

--- a/src/test/java/com/project/baedalsodae/menu/controller/MenuItemControllerTest.java
+++ b/src/test/java/com/project/baedalsodae/menu/controller/MenuItemControllerTest.java
@@ -1,0 +1,250 @@
+package com.project.baedalsodae.menu.controller;
+
+import static com.project.baedalsodae.menu.fixture.MenuTestConstants.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
+import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPatchRequestDto;
+import com.project.baedalsodae.menu.dto.requestDto.item.MenuItemPutRequestDto;
+import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryResponseDto;
+import com.project.baedalsodae.menu.dto.responseDto.item.MenuItemResponseDto;
+import com.project.baedalsodae.menu.entity.enums.MenuStatus;
+import com.project.baedalsodae.menu.fixture.MenuItemRequestFixture;
+import com.project.baedalsodae.menu.service.MenuItemService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MenuItemController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+class MenuItemControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private MenuItemService menuItemService;
+
+    private UUID menuItemId;
+    private UUID menuCategoryId;
+    private UserDetailsImpl ownerDetails;
+    private MenuItemResponseDto itemResponse;
+
+    @BeforeEach
+    void setUp() {
+        menuItemId = UUID.randomUUID();
+        menuCategoryId = UUID.randomUUID();
+        ownerDetails = createOwnerUserDetails(UUID.randomUUID());
+
+        MenuCategoryResponseDto categoryResponse =
+                new MenuCategoryResponseDto(menuCategoryId, DEFAULT_CATEGORY_NAME, 1);
+        itemResponse =
+                new MenuItemResponseDto(
+                        menuItemId,
+                        DEFAULT_MENU_ITEM_NAME,
+                        DEFAULT_ITEM_DESCRIPTION,
+                        DEFAULT_ITEM_PRICE,
+                        1,
+                        false,
+                        MenuStatus.AVAILABLE,
+                        categoryResponse,
+                        List.of(TAG_1, TAG_2));
+    }
+
+    @Test
+    @DisplayName("성공 - 메뉴 아이템 전체 수정")
+    void updateMenuItem_success() throws Exception {
+        MenuItemPutRequestDto request =
+                MenuItemRequestFixture.aPutRequest().withCategoryId(menuCategoryId).build();
+        given(menuItemService.updateMenuItem(eq(menuItemId), any(), any()))
+                .willReturn(itemResponse);
+
+        mockMvc.perform(
+                        put("/menu-items/{menuItemId}", menuItemId)
+                                .with(user(ownerDetails))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value(DEFAULT_MENU_ITEM_NAME))
+                .andDo(
+                        document(
+                                "menu-item/update",
+                                pathParameters(
+                                        parameterWithName("menuItemId").description("메뉴 아이템 ID")),
+                                requestFields(
+                                        fieldWithPath("name").description("메뉴 이름"),
+                                        fieldWithPath("description")
+                                                .description("메뉴 설명")
+                                                .optional(),
+                                        fieldWithPath("price").description("가격"),
+                                        fieldWithPath("isPopular").description("인기 메뉴 여부"),
+                                        fieldWithPath("categoryId").description("이동할 카테고리 ID"),
+                                        fieldWithPath("menuStatus")
+                                                .description(
+                                                        "메뉴 상태 (`AVAILABLE`, `SOLD_OUT`, `HIDDEN`)"),
+                                        fieldWithPath("tagNames").description("태그 목록").optional()),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data.id").description("메뉴 아이템 ID"),
+                                        fieldWithPath("data.name").description("메뉴 이름"),
+                                        fieldWithPath("data.description").description("메뉴 설명"),
+                                        fieldWithPath("data.price").description("가격"),
+                                        fieldWithPath("data.orderNo").description("정렬 순서"),
+                                        fieldWithPath("data.isPopular").description("인기 메뉴 여부"),
+                                        fieldWithPath("data.menuStatus")
+                                                .description(
+                                                        "메뉴 상태 (`AVAILABLE`, `SOLD_OUT`, `HIDDEN`)"),
+                                        fieldWithPath("data.category.id").description("카테고리 ID"),
+                                        fieldWithPath("data.category.name").description("카테고리 이름"),
+                                        fieldWithPath("data.category.orderNo")
+                                                .description("카테고리 정렬 순서"),
+                                        fieldWithPath("data.tagNames").description("태그 목록"))));
+    }
+
+    @Test
+    @DisplayName("성공 - 메뉴 아이템 부분 수정")
+    void patchMenuItem_success() throws Exception {
+        MenuItemPatchRequestDto request =
+                MenuItemRequestFixture.createPatchRequestWithName(ALTERNATIVE_MENU_ITEM_NAME);
+        given(menuItemService.patchMenuItem(eq(menuItemId), any(), any())).willReturn(itemResponse);
+
+        mockMvc.perform(
+                        patch("/menu-items/{menuItemId}", menuItemId)
+                                .with(user(ownerDetails))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "menu-item/patch",
+                                pathParameters(
+                                        parameterWithName("menuItemId").description("메뉴 아이템 ID")),
+                                requestFields(
+                                        fieldWithPath("name").description("변경할 메뉴 이름").optional(),
+                                        fieldWithPath("description")
+                                                .description("변경할 메뉴 설명")
+                                                .optional(),
+                                        fieldWithPath("price").description("변경할 가격").optional(),
+                                        fieldWithPath("isPopular")
+                                                .description("변경할 인기 메뉴 여부")
+                                                .optional(),
+                                        fieldWithPath("categoryId")
+                                                .description("이동할 카테고리 ID")
+                                                .optional(),
+                                        fieldWithPath("menuStatus")
+                                                .description(
+                                                        "변경할 메뉴 상태 (`AVAILABLE`, `SOLD_OUT`, `HIDDEN`)")
+                                                .optional(),
+                                        fieldWithPath("tagNames")
+                                                .description("변경할 태그 목록")
+                                                .optional()),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data.id").description("메뉴 아이템 ID"),
+                                        fieldWithPath("data.name").description("메뉴 이름"),
+                                        fieldWithPath("data.description").description("메뉴 설명"),
+                                        fieldWithPath("data.price").description("가격"),
+                                        fieldWithPath("data.orderNo").description("정렬 순서"),
+                                        fieldWithPath("data.isPopular").description("인기 메뉴 여부"),
+                                        fieldWithPath("data.menuStatus")
+                                                .description(
+                                                        "메뉴 상태 (`AVAILABLE`, `SOLD_OUT`, `HIDDEN`)"),
+                                        fieldWithPath("data.category.id").description("카테고리 ID"),
+                                        fieldWithPath("data.category.name").description("카테고리 이름"),
+                                        fieldWithPath("data.category.orderNo")
+                                                .description("카테고리 정렬 순서"),
+                                        fieldWithPath("data.tagNames").description("태그 목록"))));
+    }
+
+    @Test
+    @DisplayName("성공 - 메뉴 아이템 순서 변경")
+    void updateMenuItemOrder_success() throws Exception {
+        given(menuItemService.updateMenuItemOrder(eq(menuItemId), eq(2), any()))
+                .willReturn(itemResponse);
+
+        mockMvc.perform(
+                        patch("/menu-items/{menuItemId}/orders?order=2", menuItemId)
+                                .with(user(ownerDetails)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "menu-item/update-order",
+                                pathParameters(
+                                        parameterWithName("menuItemId").description("메뉴 아이템 ID")),
+                                queryParameters(
+                                        parameterWithName("order").description("변경할 정렬 순서 (1 이상)")),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data.id").description("메뉴 아이템 ID"),
+                                        fieldWithPath("data.name").description("메뉴 이름"),
+                                        fieldWithPath("data.description").description("메뉴 설명"),
+                                        fieldWithPath("data.price").description("가격"),
+                                        fieldWithPath("data.orderNo").description("변경된 정렬 순서"),
+                                        fieldWithPath("data.isPopular").description("인기 메뉴 여부"),
+                                        fieldWithPath("data.menuStatus")
+                                                .description(
+                                                        "메뉴 상태 (`AVAILABLE`, `SOLD_OUT`, `HIDDEN`)"),
+                                        fieldWithPath("data.category.id").description("카테고리 ID"),
+                                        fieldWithPath("data.category.name").description("카테고리 이름"),
+                                        fieldWithPath("data.category.orderNo")
+                                                .description("카테고리 정렬 순서"),
+                                        fieldWithPath("data.tagNames").description("태그 목록"))));
+    }
+
+    @Test
+    @DisplayName("성공 - 메뉴 아이템 삭제")
+    void deleteMenuItem_success() throws Exception {
+        willDoNothing().given(menuItemService).deleteMenuItem(eq(menuItemId), any());
+
+        mockMvc.perform(delete("/menu-items/{menuItemId}", menuItemId).with(user(ownerDetails)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "menu-item/delete",
+                                pathParameters(
+                                        parameterWithName("menuItemId").description("메뉴 아이템 ID")),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data")
+                                                .description("응답 데이터 (없음)")
+                                                .optional())));
+    }
+}

--- a/src/test/java/com/project/baedalsodae/store/controller/StoreHourControllerTest.java
+++ b/src/test/java/com/project/baedalsodae/store/controller/StoreHourControllerTest.java
@@ -1,0 +1,220 @@
+package com.project.baedalsodae.store.controller;
+
+import static com.project.baedalsodae.store.fixture.StoreHoursTestConstants.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
+import com.project.baedalsodae.store.dto.request.StoreHoursRequest;
+import com.project.baedalsodae.store.dto.response.StoreHoursResponse;
+import com.project.baedalsodae.store.entity.enums.DayOfWeek;
+import com.project.baedalsodae.store.fixture.StoreHoursRequestFixture;
+import com.project.baedalsodae.store.service.StoreHoursService;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(StoreHourController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+class StoreHourControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private StoreHoursService storeHoursService;
+
+    private UUID storeId;
+    private UserDetailsImpl ownerDetails;
+    private List<StoreHoursRequest> requests;
+    private StoreHoursResponse.StoreHoursInfo storeHoursInfo;
+
+    @BeforeEach
+    void setUp() {
+        storeId = UUID.randomUUID();
+        ownerDetails = createOwnerUserDetails(UUID.randomUUID());
+        requests = StoreHoursRequestFixture.createDefaultRequests();
+
+        List<StoreHoursResponse.StoreHourDto> hourDtos =
+                Arrays.stream(DayOfWeek.values())
+                        .map(
+                                day ->
+                                        StoreHoursResponse.StoreHourDto.builder()
+                                                .storeHoursId(UUID.randomUUID())
+                                                .dayOfWeek(day)
+                                                .openTime(DEFAULT_OPEN_TIME)
+                                                .closeTime(DEFAULT_CLOSE_TIME)
+                                                .breakStart(DEFAULT_BREAK_START)
+                                                .breakEnd(DEFAULT_BREAK_END)
+                                                .isOpen(true)
+                                                .build())
+                        .toList();
+
+        storeHoursInfo = new StoreHoursResponse.StoreHoursInfo(storeId, hourDtos);
+    }
+
+    @Test
+    @DisplayName("성공 - 영업시간 등록")
+    void createStoreHours_success() throws Exception {
+        willDoNothing().given(storeHoursService).createStoreHours(eq(storeId), any(), any());
+
+        mockMvc.perform(
+                        post("/stores/{storeId}/hours", storeId)
+                                .with(user(ownerDetails))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requests)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "store-hours/create",
+                                pathParameters(parameterWithName("storeId").description("가게 ID")),
+                                requestFields(
+                                        fieldWithPath("[].dayOfWeek")
+                                                .description(
+                                                        "요일 (`MON`, `TUE`, `WED`, `THU`, `FRI`, `SAT`, `SUN`)"),
+                                        fieldWithPath("[].openTime")
+                                                .description("영업 시작 시간 (HH:mm:ss)"),
+                                        fieldWithPath("[].closeTime")
+                                                .description("영업 종료 시간 (HH:mm:ss)"),
+                                        fieldWithPath("[].breakStart")
+                                                .description("브레이크 시작 시간 (선택)")
+                                                .optional(),
+                                        fieldWithPath("[].breakEnd")
+                                                .description("브레이크 종료 시간 (선택)")
+                                                .optional(),
+                                        fieldWithPath("[].open").description("영업 여부"),
+                                        fieldWithPath("[].validOpenCloseTime").ignored(),
+                                        fieldWithPath("[].validBreakTime").ignored()),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data")
+                                                .description("응답 데이터 (없음)")
+                                                .optional())));
+    }
+
+    @Test
+    @DisplayName("성공 - 영업시간 조회")
+    void getStoreHours_success() throws Exception {
+        given(storeHoursService.getStoreHours(eq(storeId))).willReturn(storeHoursInfo);
+
+        mockMvc.perform(get("/stores/{storeId}/hours", storeId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "store-hours/get",
+                                pathParameters(parameterWithName("storeId").description("가게 ID")),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data.storeId").description("가게 ID"),
+                                        fieldWithPath("data.storeHours[].storeHoursId")
+                                                .description("영업시간 ID"),
+                                        fieldWithPath("data.storeHours[].dayOfWeek")
+                                                .description(
+                                                        "요일 (`MON`, `TUE`, `WED`, `THU`, `FRI`, `SAT`, `SUN`)"),
+                                        fieldWithPath("data.storeHours[].openTime")
+                                                .description("영업 시작 시간"),
+                                        fieldWithPath("data.storeHours[].closeTime")
+                                                .description("영업 종료 시간"),
+                                        fieldWithPath("data.storeHours[].breakStart")
+                                                .description("브레이크 시작 시간"),
+                                        fieldWithPath("data.storeHours[].breakEnd")
+                                                .description("브레이크 종료 시간"),
+                                        fieldWithPath("data.storeHours[].open")
+                                                .description("영업 여부"),
+                                        fieldWithPath("data.empty").ignored())));
+    }
+
+    @Test
+    @DisplayName("성공 - 영업시간 수정")
+    void updateStoreHours_success() throws Exception {
+        willDoNothing().given(storeHoursService).updateStoreHours(eq(storeId), any(), any());
+
+        mockMvc.perform(
+                        patch("/stores/{storeId}/hours", storeId)
+                                .with(user(ownerDetails))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requests)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "store-hours/update",
+                                pathParameters(parameterWithName("storeId").description("가게 ID")),
+                                requestFields(
+                                        fieldWithPath("[].dayOfWeek")
+                                                .description(
+                                                        "요일 (`MON`, `TUE`, `WED`, `THU`, `FRI`, `SAT`, `SUN`)"),
+                                        fieldWithPath("[].openTime")
+                                                .description("영업 시작 시간 (HH:mm:ss)"),
+                                        fieldWithPath("[].closeTime")
+                                                .description("영업 종료 시간 (HH:mm:ss)"),
+                                        fieldWithPath("[].breakStart")
+                                                .description("브레이크 시작 시간 (선택)")
+                                                .optional(),
+                                        fieldWithPath("[].breakEnd")
+                                                .description("브레이크 종료 시간 (선택)")
+                                                .optional(),
+                                        fieldWithPath("[].open").description("영업 여부"),
+                                        fieldWithPath("[].validOpenCloseTime").ignored(),
+                                        fieldWithPath("[].validBreakTime").ignored()),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data")
+                                                .description("응답 데이터 (없음)")
+                                                .optional())));
+    }
+
+    @Test
+    @DisplayName("성공 - 영업시간 삭제")
+    void deleteStoreHours_success() throws Exception {
+        willDoNothing().given(storeHoursService).deleteStoreHours(eq(storeId), any());
+
+        mockMvc.perform(delete("/stores/{storeId}/hours", storeId).with(user(ownerDetails)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document(
+                                "store-hours/delete",
+                                pathParameters(parameterWithName("storeId").description("가게 ID")),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("HTTP 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("timestamp").ignored(),
+                                        fieldWithPath("data")
+                                                .description("응답 데이터 (없음)")
+                                                .optional())));
+    }
+}

--- a/src/test/java/com/project/baedalsodae/store/service/StoreCommandServiceTest.java
+++ b/src/test/java/com/project/baedalsodae/store/service/StoreCommandServiceTest.java
@@ -17,7 +17,6 @@ import com.project.baedalsodae.store.entity.enums.StoreStatus;
 import com.project.baedalsodae.store.repository.StoreCategoryRepository;
 import com.project.baedalsodae.store.repository.StoreRepository;
 import com.project.baedalsodae.store.service.impl.StoreCommandServiceImpl;
-import com.project.baedalsodae.store.service.StoreHoursService;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/project/baedalsodae/store/service/StoreCommandServiceTest.java
+++ b/src/test/java/com/project/baedalsodae/store/service/StoreCommandServiceTest.java
@@ -17,6 +17,7 @@ import com.project.baedalsodae.store.entity.enums.StoreStatus;
 import com.project.baedalsodae.store.repository.StoreCategoryRepository;
 import com.project.baedalsodae.store.repository.StoreRepository;
 import com.project.baedalsodae.store.service.impl.StoreCommandServiceImpl;
+import com.project.baedalsodae.store.service.StoreHoursService;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,8 @@ class StoreCommandServiceTest {
     @Mock private StoreRepository storeRepository;
 
     @Mock private StoreCategoryRepository storeCategoryRepository;
+
+    @Mock private StoreHoursService storeHoursService;
 
     @InjectMocks private StoreCommandServiceImpl storeCommandService;
 

--- a/src/test/java/com/project/baedalsodae/store/service/StoreHoursServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/store/service/StoreHoursServiceImplTest.java
@@ -17,6 +17,7 @@ import com.project.baedalsodae.store.entity.StoreHours;
 import com.project.baedalsodae.store.repository.StoreHoursRepository;
 import com.project.baedalsodae.store.repository.StoreRepository;
 import com.project.baedalsodae.store.service.impl.StoreHoursServiceImpl;
+import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -34,6 +35,7 @@ class StoreHoursServiceImplTest {
 
     @Mock private StoreHoursRepository storeHoursRepository;
     @Mock private StoreRepository storeRepository;
+    @Mock private EntityManager entityManager;
 
     @InjectMocks private StoreHoursServiceImpl storeHoursService;
 


### PR DESCRIPTION
### 📌 관련 이슈
- close #121

### 💡 작업 내용
  - Spring REST Docs 설정 추가 (build.gradle - asciidoctor 플러그인, 의존성)
- 작업한 부분 RestDocs로 문서화

### 🔍 변경 이유
  - ./gradlew asciidoctor 실행 시 테스트 기반으로 API 문서가 자동 생성되도록 하기 위함
  - 테스트가 통과해야만 문서가 빌드되는 구조로, 문서와 실제 API의 일치를 보장
  - 기존 테스트 중 Mock 누락(StoreHoursService, EntityManager)으로 인한 NPE 수정

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
  - ./gradlew asciidoctor 실행 흐름: 테스트 → build/generated-snippets/ → .adoc include → build/docs/asciidoc/*.html
