### PR TITLE
Feat/143 location filter

### DIFF
--- a/src/main/java/com/project/baedalsodae/allowedRegion/entity/AllowedRegion.java
+++ b/src/main/java/com/project/baedalsodae/allowedRegion/entity/AllowedRegion.java
@@ -1,0 +1,67 @@
+package com.project.baedalsodae.allowedRegion.entity;
+
+import com.project.baedalsodae.global.common.entity.BaseAuditEntity;
+import jakarta.persistence.*;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "p_allowed_region",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uq_allowed_region_sigungu_code",
+                    columnNames = {"sigungu_code"}),
+            @UniqueConstraint(
+                    name = "uq_allowed_region_sido_sigungu_code",
+                    columnNames = {"sido_code", "sigungu_code"})
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AllowedRegion extends BaseAuditEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "sido_code", length = 20, nullable = false)
+    private String sidoCode;
+
+    @Column(name = "sido_name", length = 50, nullable = false)
+    private String sidoName;
+
+    @Column(name = "sigungu_code", length = 20, nullable = false, unique = true)
+    private String sigunguCode;
+
+    @Column(name = "sigungu_name", length = 50, nullable = false)
+    private String sigunguName;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive = true;
+
+    private AllowedRegion(
+            String sidoCode, String sidoName, String sigunguCode, String sigunguName) {
+        this.sidoCode = sidoCode;
+        this.sidoName = sidoName;
+        this.sigunguCode = sigunguCode;
+        this.sigunguName = sigunguName;
+    }
+
+    public static AllowedRegion create(
+            String sidoCode, String sidoName, String sigunguCode, String sigunguName) {
+        return new AllowedRegion(sidoCode, sidoName, sigunguCode, sigunguName);
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+}

--- a/src/main/java/com/project/baedalsodae/allowedRegion/repository/AllowedRegionRepository.java
+++ b/src/main/java/com/project/baedalsodae/allowedRegion/repository/AllowedRegionRepository.java
@@ -1,0 +1,12 @@
+package com.project.baedalsodae.allowedRegion.repository;
+
+import com.project.baedalsodae.allowedRegion.entity.AllowedRegion;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AllowedRegionRepository extends JpaRepository<AllowedRegion, UUID> {
+    Optional<AllowedRegion> findBySigunguCodeAndIsDeletedIsFalse(String sigunguCode);
+
+    Optional<AllowedRegion> findBySigunguNameAndIsDeletedIsFalse(String sigunguName);
+}

--- a/src/main/java/com/project/baedalsodae/allowedRegion/service/AllowedRegionService.java
+++ b/src/main/java/com/project/baedalsodae/allowedRegion/service/AllowedRegionService.java
@@ -1,0 +1,11 @@
+package com.project.baedalsodae.allowedRegion.service;
+
+import com.project.baedalsodae.global.common.entity.Address;
+import com.project.baedalsodae.user.entity.UserAddress;
+
+public interface AllowedRegionService {
+
+  boolean isAllowedByCode(String sigunguCode);
+
+  boolean isAllowedByName(String sigunguName);
+}

--- a/src/main/java/com/project/baedalsodae/allowedRegion/service/AllowedRegionService.java
+++ b/src/main/java/com/project/baedalsodae/allowedRegion/service/AllowedRegionService.java
@@ -1,11 +1,8 @@
 package com.project.baedalsodae.allowedRegion.service;
 
-import com.project.baedalsodae.global.common.entity.Address;
-import com.project.baedalsodae.user.entity.UserAddress;
-
 public interface AllowedRegionService {
 
-  boolean isAllowedByCode(String sigunguCode);
+    boolean isAllowedByCode(String sigunguCode);
 
-  boolean isAllowedByName(String sigunguName);
+    boolean isAllowedByName(String sigunguName);
 }

--- a/src/main/java/com/project/baedalsodae/allowedRegion/service/impl/AllowedRegionServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/allowedRegion/service/impl/AllowedRegionServiceImpl.java
@@ -1,0 +1,34 @@
+package com.project.baedalsodae.allowedRegion.service.impl;
+
+import com.project.baedalsodae.allowedRegion.entity.AllowedRegion;
+import com.project.baedalsodae.allowedRegion.repository.AllowedRegionRepository;
+import com.project.baedalsodae.allowedRegion.service.AllowedRegionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AllowedRegionServiceImpl implements AllowedRegionService {
+
+    private final AllowedRegionRepository allowedRegionRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isAllowedByCode(String sigunguCode) {
+        return allowedRegionRepository
+                .findBySigunguCodeAndIsDeletedIsFalse(sigunguCode)
+                .map(AllowedRegion::isActive)
+                .orElse(false);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isAllowedByName(String sigunguName) {
+        return allowedRegionRepository
+                .findBySigunguNameAndIsDeletedIsFalse(sigunguName)
+                .map(AllowedRegion::isActive)
+                .orElse(false);
+    }
+
+}

--- a/src/main/java/com/project/baedalsodae/allowedRegion/service/impl/AllowedRegionServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/allowedRegion/service/impl/AllowedRegionServiceImpl.java
@@ -30,5 +30,4 @@ public class AllowedRegionServiceImpl implements AllowedRegionService {
                 .map(AllowedRegion::isActive)
                 .orElse(false);
     }
-
 }

--- a/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
+++ b/src/main/java/com/project/baedalsodae/global/common/ErrorCode.java
@@ -98,7 +98,14 @@ public enum ErrorCode {
     REVIEW_NOT_FOUND("RV003", HttpStatus.NOT_FOUND, "리뷰가 없습니다."),
     REVIEW_UNAUTHORIZED("RV004", HttpStatus.UNAUTHORIZED, "이 리뷰에 대한 권한이 없습니다."),
     REVIEW_BEFORE_DELIVERY_NOT_ALLOWED(
-            "RV005", HttpStatus.BAD_REQUEST, "배송 완료 전에는 리뷰를 작성할 수 없습니다.");
+            "RV005", HttpStatus.BAD_REQUEST, "배송 완료 전에는 리뷰를 작성할 수 없습니다."),
+
+    // Address
+    INVALID_ADDRESS_VALUE("AD001", HttpStatus.BAD_REQUEST, "유효하지 않은 주소 값입니다."),
+    ADDRESS_DUPLICATED("AD002", HttpStatus.CONFLICT, "이미 존재하는 허용 주소입니다."),
+    USER_ADDRESS_NOT_ALLOWED("AD003", HttpStatus.BAD_REQUEST, "배달 가능한 지역이 아닙니다."),
+    STORE_REGION_NOT_ALLOWED("AD004", HttpStatus.BAD_REQUEST, "해당 가게는 서비스 지원 지역이 아닙니다.");
+
     private final String code;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/project/baedalsodae/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/order/service/impl/OrderServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.baedalsodae.order.service.impl;
 
+import com.project.baedalsodae.allowedRegion.service.AllowedRegionService;
 import com.project.baedalsodae.cart.entity.Cart;
 import com.project.baedalsodae.cart.repository.CartRepository;
 import com.project.baedalsodae.global.common.BusinessException;
@@ -24,7 +25,9 @@ import com.project.baedalsodae.payment.entity.PaymentStatus;
 import com.project.baedalsodae.payment.repository.PaymentRepository;
 import com.project.baedalsodae.store.entity.Store;
 import com.project.baedalsodae.store.repository.StoreRepository;
+import com.project.baedalsodae.user.entity.UserAddress;
 import com.project.baedalsodae.user.entity.UserRole;
+import com.project.baedalsodae.user.service.UserAddressService;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -46,6 +49,8 @@ public class OrderServiceImpl implements OrderService {
     private final OrderEventPublisher orderEventPublisher;
     private final OrderQueryRepository orderQueryRepository;
     private final PaymentRepository paymentRepository;
+    private final AllowedRegionService allowedRegionService;
+    private final UserAddressService userAddressService;
 
     @Override
     @Transactional
@@ -65,6 +70,10 @@ public class OrderServiceImpl implements OrderService {
                         .findByIdAndIsDeletedIsFalse(storeId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
+        if(!allowedRegionService.isAllowedByCode(store.getAddress().getSigunguCode())){
+            throw new BusinessException(ErrorCode.STORE_REGION_NOT_ALLOWED);
+        }
+
         BigDecimal totalAmount = cart.getTotalAmount();
         if (totalAmount.compareTo(BigDecimal.ZERO) <= 0)
             throw new BusinessException(ErrorCode.ORDER_INVALID_TOTAL_AMOUNT);
@@ -75,6 +84,11 @@ public class OrderServiceImpl implements OrderService {
         final BigDecimal finalAmount = totalAmount.subtract(discountAmount).add(deliveryFee);
         if (finalAmount.compareTo(BigDecimal.ZERO) < 0)
             throw new BusinessException(ErrorCode.ORDER_INVALID_FINAL_AMOUNT);
+
+        UserAddress userAddress = userAddressService.getMainUserAddress(userId);
+        if(!allowedRegionService.isAllowedByCode(userAddress.getAddress().getSigunguCode())){
+            throw new BusinessException(ErrorCode.USER_ADDRESS_NOT_ALLOWED);
+        }
 
         // TODO 주소 도메인 완성 후 만들어야함. 주소 조회, 주소를 배달 주소 스냅샷으로 변환
         String deliveryAddressSnapshot = "서울특별시 강남구 테헤란로 123 (역삼동) 4층";

--- a/src/main/java/com/project/baedalsodae/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/order/service/impl/OrderServiceImpl.java
@@ -70,7 +70,7 @@ public class OrderServiceImpl implements OrderService {
                         .findByIdAndIsDeletedIsFalse(storeId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
-        if(!allowedRegionService.isAllowedByCode(store.getAddress().getSigunguCode())){
+        if (!allowedRegionService.isAllowedByCode(store.getAddress().getSigunguCode())) {
             throw new BusinessException(ErrorCode.STORE_REGION_NOT_ALLOWED);
         }
 
@@ -86,7 +86,7 @@ public class OrderServiceImpl implements OrderService {
             throw new BusinessException(ErrorCode.ORDER_INVALID_FINAL_AMOUNT);
 
         UserAddress userAddress = userAddressService.getMainUserAddress(userId);
-        if(!allowedRegionService.isAllowedByCode(userAddress.getAddress().getSigunguCode())){
+        if (!allowedRegionService.isAllowedByCode(userAddress.getAddress().getSigunguCode())) {
             throw new BusinessException(ErrorCode.USER_ADDRESS_NOT_ALLOWED);
         }
 

--- a/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
+++ b/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
@@ -53,8 +53,9 @@ public class StoreController {
     public ResponseEntity<ApiResponse<StoreDetailResponse>> getStoreDetail(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable("storeId") UUID storeId) {
-        StoreDetailResponse response = storeQueryService.getStoreDetail(storeId,userDetails.getUserId());
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.STORE_DETAIL_FOUND, response ));
+        StoreDetailResponse response =
+                storeQueryService.getStoreDetail(storeId, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.STORE_DETAIL_FOUND, response));
     }
 
     @PreAuthorize("hasAnyAuthority('ROLE_OWNER','ROLE_MANAGER')")

--- a/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
+++ b/src/main/java/com/project/baedalsodae/store/controller/StoreController.java
@@ -51,9 +51,10 @@ public class StoreController {
     @PreAuthorize("hasAnyAuthority('ROLE_CUSTOMER', 'ROLE_OWNER', 'ROLE_MANAGER')")
     @GetMapping("/{storeId}")
     public ResponseEntity<ApiResponse<StoreDetailResponse>> getStoreDetail(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable("storeId") UUID storeId) {
-        StoreDetailResponse response = storeQueryService.getStoreDetail(storeId);
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.STORE_DETAIL_FOUND, response));
+        StoreDetailResponse response = storeQueryService.getStoreDetail(storeId,userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.STORE_DETAIL_FOUND, response ));
     }
 
     @PreAuthorize("hasAnyAuthority('ROLE_OWNER','ROLE_MANAGER')")

--- a/src/main/java/com/project/baedalsodae/store/dto/response/store/StoreDetailResponse.java
+++ b/src/main/java/com/project/baedalsodae/store/dto/response/store/StoreDetailResponse.java
@@ -10,13 +10,19 @@ import lombok.Getter;
 public class StoreDetailResponse {
     private StoreSummaryResponse store;
     private List<MenuCategoryItemsResponse> storeMenuCategoryItems;
+    private boolean isAllowedRegion;
+    private boolean isDeliverableToUser;
+
 
     public static StoreDetailResponse of(
             StoreSummaryResponse store,
-            List<MenuCategoryItemsResponse> storeMenuCategoryItemsList) {
+            List<MenuCategoryItemsResponse> storeMenuCategoryItemsList,
+            boolean isAllowedRegion, boolean isDeliverableToUser) {
         return StoreDetailResponse.builder()
                 .store(store)
                 .storeMenuCategoryItems(storeMenuCategoryItemsList)
+                .isAllowedRegion(isAllowedRegion)
+                .isDeliverableToUser(isDeliverableToUser)
                 .build();
     }
 }

--- a/src/main/java/com/project/baedalsodae/store/dto/response/store/StoreDetailResponse.java
+++ b/src/main/java/com/project/baedalsodae/store/dto/response/store/StoreDetailResponse.java
@@ -13,11 +13,11 @@ public class StoreDetailResponse {
     private boolean isAllowedRegion;
     private boolean isDeliverableToUser;
 
-
     public static StoreDetailResponse of(
             StoreSummaryResponse store,
             List<MenuCategoryItemsResponse> storeMenuCategoryItemsList,
-            boolean isAllowedRegion, boolean isDeliverableToUser) {
+            boolean isAllowedRegion,
+            boolean isDeliverableToUser) {
         return StoreDetailResponse.builder()
                 .store(store)
                 .storeMenuCategoryItems(storeMenuCategoryItemsList)

--- a/src/main/java/com/project/baedalsodae/store/service/StoreQueryService.java
+++ b/src/main/java/com/project/baedalsodae/store/service/StoreQueryService.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Pageable;
 public interface StoreQueryService {
     StoreSearchPageResponse getStoreByKeyword(String keyword, Pageable pageable, SortType sortType);
 
-    StoreDetailResponse getStoreDetail(UUID storeId);
+    StoreDetailResponse getStoreDetail(UUID storeId, UUID userId);
 
     OwnerStoreResponse getOwnerStore(UUID storeId, UUID userId, UserRole role);
 

--- a/src/main/java/com/project/baedalsodae/store/service/impl/StoreQueryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/store/service/impl/StoreQueryServiceImpl.java
@@ -76,12 +76,14 @@ public class StoreQueryServiceImpl implements StoreQueryService {
         List<MenuCategoryItemsResponse> storeMenuCategoryItemsList =
                 menuCategoryCustomRepository.getStoreCategoryItems(storeId);
         UserAddress userAddress = userAddressService.getMainUserAddress(userId);
-        boolean isDeliverable = allowedRegionService.isAllowedByCode(userAddress.getAddress().getSigunguCode());
+        boolean isDeliverable =
+                allowedRegionService.isAllowedByCode(userAddress.getAddress().getSigunguCode());
 
         return StoreDetailResponse.of(
                 StoreSummaryResponse.fromEntity(store),
                 storeMenuCategoryItemsList,
-                isAllowedRegion,isDeliverable);
+                isAllowedRegion,
+                isDeliverable);
     }
 
     @Override

--- a/src/main/java/com/project/baedalsodae/store/service/impl/StoreQueryServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/store/service/impl/StoreQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.baedalsodae.store.service.impl;
 
+import com.project.baedalsodae.allowedRegion.service.AllowedRegionService;
 import com.project.baedalsodae.global.common.BusinessException;
 import com.project.baedalsodae.global.common.ErrorCode;
 import com.project.baedalsodae.menu.dto.responseDto.category.MenuCategoryItemsResponse;
@@ -13,7 +14,9 @@ import com.project.baedalsodae.store.repository.StoreCategoryRepository;
 import com.project.baedalsodae.store.repository.StoreRepository;
 import com.project.baedalsodae.store.repository.custom.StoreCustomRepository;
 import com.project.baedalsodae.store.service.StoreQueryService;
+import com.project.baedalsodae.user.entity.UserAddress;
 import com.project.baedalsodae.user.entity.UserRole;
+import com.project.baedalsodae.user.service.UserAddressService;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +31,8 @@ public class StoreQueryServiceImpl implements StoreQueryService {
     private final StoreCustomRepository storeCustomRepository;
     private final StoreCategoryRepository storeCategoryRepository;
     private final MenuCategoryCustomRepository menuCategoryCustomRepository;
+    private final AllowedRegionService allowedRegionService;
+    private final UserAddressService userAddressService;
 
     @Override
     public StorePageResponse getStorePage(UUID storeCategoryId, StoreCursorRequest cursorRequest) {
@@ -63,14 +68,20 @@ public class StoreQueryServiceImpl implements StoreQueryService {
     }
 
     @Override
-    public StoreDetailResponse getStoreDetail(UUID storeId) {
+    public StoreDetailResponse getStoreDetail(UUID storeId, UUID userId) {
         Store store = getStore(storeId);
 
+        String sigunguCode = store.getAddress().getSigunguCode();
+        boolean isAllowedRegion = allowedRegionService.isAllowedByCode(sigunguCode);
         List<MenuCategoryItemsResponse> storeMenuCategoryItemsList =
                 menuCategoryCustomRepository.getStoreCategoryItems(storeId);
+        UserAddress userAddress = userAddressService.getMainUserAddress(userId);
+        boolean isDeliverable = allowedRegionService.isAllowedByCode(userAddress.getAddress().getSigunguCode());
 
         return StoreDetailResponse.of(
-                StoreSummaryResponse.fromEntity(store), storeMenuCategoryItemsList);
+                StoreSummaryResponse.fromEntity(store),
+                storeMenuCategoryItemsList,
+                isAllowedRegion,isDeliverable);
     }
 
     @Override

--- a/src/main/java/com/project/baedalsodae/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/project/baedalsodae/user/repository/UserAddressRepository.java
@@ -4,6 +4,7 @@ import com.project.baedalsodae.user.entity.UserAddress;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserAddressRepository extends JpaRepository<UserAddress, UUID> {
 
@@ -16,4 +17,8 @@ public interface UserAddressRepository extends JpaRepository<UserAddress, UUID> 
     Optional<UserAddress> findByIdAndUserId(UUID addressId, UUID userId);
 
     void deleteAllByUserId(UUID uuid);
+
+    @Query(
+            "SELECT ua FROM UserAddress ua WHERE ua.id = (SELECT u.userMainAddressId FROM User u WHERE u.id = :userId)")
+    Optional<UserAddress> findMainAddressByUserId(UUID userId);
 }

--- a/src/main/java/com/project/baedalsodae/user/service/UserAddressService.java
+++ b/src/main/java/com/project/baedalsodae/user/service/UserAddressService.java
@@ -3,6 +3,7 @@ package com.project.baedalsodae.user.service;
 import com.project.baedalsodae.user.dto.request.CreateUserAddressRequest;
 import com.project.baedalsodae.user.dto.request.UpdateUserAddressRequest;
 import com.project.baedalsodae.user.dto.response.UserAddressResponse;
+import com.project.baedalsodae.user.entity.UserAddress;
 import java.util.List;
 import java.util.UUID;
 
@@ -24,4 +25,6 @@ public interface UserAddressService {
     void deleteAllAddressesByUserId(UUID userId);
 
     void setMainAddress(UUID userId, UUID addressId);
+
+    UserAddress getMainUserAddress(UUID userId);
 }

--- a/src/main/java/com/project/baedalsodae/user/service/impl/UserAddressServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/user/service/impl/UserAddressServiceImpl.java
@@ -204,4 +204,11 @@ public class UserAddressServiceImpl implements UserAddressService {
         user.changeMainAddress(null);
         user.getUserAddresses().clear();
     }
+
+    @Override
+    public UserAddress getMainUserAddress(UUID userId) {
+        return userAddressRepository
+                .findMainAddressByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_ADDRESS_NOT_FOUND));
+    }
 }

--- a/src/test/java/com/project/baedalsodae/allowedRegion/service/AllowedRegionServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/allowedRegion/service/AllowedRegionServiceImplTest.java
@@ -3,6 +3,7 @@ package com.project.baedalsodae.allowedRegion.service;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
+
 import com.project.baedalsodae.allowedRegion.entity.AllowedRegion;
 import com.project.baedalsodae.allowedRegion.repository.AllowedRegionRepository;
 import com.project.baedalsodae.allowedRegion.service.impl.AllowedRegionServiceImpl;
@@ -34,7 +35,8 @@ class AllowedRegionServiceImplTest {
         @Test
         @DisplayName("지역이 존재하고 활성화 상태이면 true를 반환한다")
         void returnsTrueWhenActiveRegionExists() {
-            AllowedRegion region = AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
+            AllowedRegion region =
+                    AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
             given(allowedRegionRepository.findBySigunguCodeAndIsDeletedIsFalse(SIGUNGU_CODE))
                     .willReturn(Optional.of(region));
 
@@ -46,7 +48,8 @@ class AllowedRegionServiceImplTest {
         @Test
         @DisplayName("지역이 존재하지만 비활성화 상태이면 false를 반환한다")
         void returnsFalseWhenInactiveRegionExists() {
-            AllowedRegion region = AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
+            AllowedRegion region =
+                    AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
             region.deactivate();
             given(allowedRegionRepository.findBySigunguCodeAndIsDeletedIsFalse(SIGUNGU_CODE))
                     .willReturn(Optional.of(region));
@@ -75,7 +78,8 @@ class AllowedRegionServiceImplTest {
         @Test
         @DisplayName("지역이 존재하고 활성화 상태이면 true를 반환한다")
         void returnsTrueWhenActiveRegionExists() {
-            AllowedRegion region = AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
+            AllowedRegion region =
+                    AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
             given(allowedRegionRepository.findBySigunguNameAndIsDeletedIsFalse(SIGUNGU_NAME))
                     .willReturn(Optional.of(region));
 
@@ -87,7 +91,8 @@ class AllowedRegionServiceImplTest {
         @Test
         @DisplayName("지역이 존재하지만 비활성화 상태이면 false를 반환한다")
         void returnsFalseWhenInactiveRegionExists() {
-            AllowedRegion region = AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
+            AllowedRegion region =
+                    AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
             region.deactivate();
             given(allowedRegionRepository.findBySigunguNameAndIsDeletedIsFalse(SIGUNGU_NAME))
                     .willReturn(Optional.of(region));

--- a/src/test/java/com/project/baedalsodae/allowedRegion/service/AllowedRegionServiceImplTest.java
+++ b/src/test/java/com/project/baedalsodae/allowedRegion/service/AllowedRegionServiceImplTest.java
@@ -1,0 +1,111 @@
+package com.project.baedalsodae.allowedRegion.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import com.project.baedalsodae.allowedRegion.entity.AllowedRegion;
+import com.project.baedalsodae.allowedRegion.repository.AllowedRegionRepository;
+import com.project.baedalsodae.allowedRegion.service.impl.AllowedRegionServiceImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AllowedRegionServiceImplTest {
+
+    @Mock private AllowedRegionRepository allowedRegionRepository;
+
+    @InjectMocks private AllowedRegionServiceImpl allowedRegionService;
+
+    private static final String SIDO_CODE = "11";
+    private static final String SIDO_NAME = "서울특별시";
+    private static final String SIGUNGU_CODE = "11010";
+    private static final String SIGUNGU_NAME = "종로구";
+
+    @Nested
+    @DisplayName("isAllowedByCode")
+    class IsAllowedByCode {
+
+        @Test
+        @DisplayName("지역이 존재하고 활성화 상태이면 true를 반환한다")
+        void returnsTrueWhenActiveRegionExists() {
+            AllowedRegion region = AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
+            given(allowedRegionRepository.findBySigunguCodeAndIsDeletedIsFalse(SIGUNGU_CODE))
+                    .willReturn(Optional.of(region));
+
+            boolean result = allowedRegionService.isAllowedByCode(SIGUNGU_CODE);
+
+            assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("지역이 존재하지만 비활성화 상태이면 false를 반환한다")
+        void returnsFalseWhenInactiveRegionExists() {
+            AllowedRegion region = AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
+            region.deactivate();
+            given(allowedRegionRepository.findBySigunguCodeAndIsDeletedIsFalse(SIGUNGU_CODE))
+                    .willReturn(Optional.of(region));
+
+            boolean result = allowedRegionService.isAllowedByCode(SIGUNGU_CODE);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("지역이 존재하지 않으면 false를 반환한다")
+        void returnsFalseWhenRegionNotFound() {
+            given(allowedRegionRepository.findBySigunguCodeAndIsDeletedIsFalse(SIGUNGU_CODE))
+                    .willReturn(Optional.empty());
+
+            boolean result = allowedRegionService.isAllowedByCode(SIGUNGU_CODE);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("isAllowedByName")
+    class IsAllowedByName {
+
+        @Test
+        @DisplayName("지역이 존재하고 활성화 상태이면 true를 반환한다")
+        void returnsTrueWhenActiveRegionExists() {
+            AllowedRegion region = AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
+            given(allowedRegionRepository.findBySigunguNameAndIsDeletedIsFalse(SIGUNGU_NAME))
+                    .willReturn(Optional.of(region));
+
+            boolean result = allowedRegionService.isAllowedByName(SIGUNGU_NAME);
+
+            assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("지역이 존재하지만 비활성화 상태이면 false를 반환한다")
+        void returnsFalseWhenInactiveRegionExists() {
+            AllowedRegion region = AllowedRegion.create(SIDO_CODE, SIDO_NAME, SIGUNGU_CODE, SIGUNGU_NAME);
+            region.deactivate();
+            given(allowedRegionRepository.findBySigunguNameAndIsDeletedIsFalse(SIGUNGU_NAME))
+                    .willReturn(Optional.of(region));
+
+            boolean result = allowedRegionService.isAllowedByName(SIGUNGU_NAME);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("지역이 존재하지 않으면 false를 반환한다")
+        void returnsFalseWhenRegionNotFound() {
+            given(allowedRegionRepository.findBySigunguNameAndIsDeletedIsFalse(SIGUNGU_NAME))
+                    .willReturn(Optional.empty());
+
+            boolean result = allowedRegionService.isAllowedByName(SIGUNGU_NAME);
+
+            assertFalse(result);
+        }
+    }
+}

--- a/src/test/java/com/project/baedalsodae/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/project/baedalsodae/store/controller/StoreControllerTest.java
@@ -55,6 +55,7 @@ class StoreControllerTest {
 
     private static final UUID STORE_ID = UUID.randomUUID();
     private static final UUID CATEGORY_ID = UUID.randomUUID();
+    private static final UUID USER_ID = UUID.randomUUID();
     private static final UserDetailsImpl ownerDetails = createOwnerUserDetails(UUID.randomUUID());
 
     private static UserDetailsImpl createOwnerUserDetails(UUID userId) {
@@ -233,9 +234,10 @@ class StoreControllerTest {
     @DisplayName("가게 상세 조회 - 성공")
     void getStoreDetail_success() throws Exception {
 
-        StoreDetailResponse detailResponse = StoreDetailResponse.of(storeSummary(), List.of());
+        StoreDetailResponse detailResponse =
+                StoreDetailResponse.of(storeSummary(), List.of(), true, true);
 
-        given(storeQueryService.getStoreDetail(STORE_ID)).willReturn(detailResponse);
+        given(storeQueryService.getStoreDetail(STORE_ID, USER_ID)).willReturn(detailResponse);
 
         mockMvc.perform(
                         get("/stores/{storeId}", STORE_ID)

--- a/src/test/java/com/project/baedalsodae/store/service/StoreQueryServiceTest.java
+++ b/src/test/java/com/project/baedalsodae/store/service/StoreQueryServiceTest.java
@@ -96,7 +96,7 @@ class StoreQueryServiceTest {
                     .willReturn(mockMenuList);
 
             // when
-            StoreDetailResponse response = storeQueryService.getStoreDetail(storeId);
+            StoreDetailResponse response = storeQueryService.getStoreDetail(storeId, userId);
 
             // then
             assertThat(response).isNotNull();


### PR DESCRIPTION
### 📌 관련 이슈
- close #143

### 💡 작업 내용                                                                                                                                                                                                                
  - 서비스 허용 지역(AllowedRegion) 엔티티 및 시군구 코드/이름 기반 허용 여부 조회 서비스 추가                                                                                                                                     
  - 가게 상세 조회 시 해당 가게의 지역 허용 여부(isAllowedRegion)와 유저 메인 주소 기반 배달 가능 여부(isDeliverableToUser) 응답에 포함
  - 주문 생성 시 가게 지역 및 유저 메인 주소 지역 허용 여부 검증 추가


### 🔍 변경 이유
  - 배달 서비스 제공 가능 지역을 DB로 관리하고, 주문 및 가게 조회 시점에 유효성을 검증하기 위해
  - 기존에는 지역 필터링 없이 주문이 생성될 수 있었기 때문에, 허용되지 않은 지역의 가게에 대한 주문을 차단하는 로직이 필요했음

### 📝 리뷰 포인트 (선택)
  - getStoreDetail에 userId를 추가로 받도록 시그니처를 변경했는데, 해당 파라미터 전달 흐름이 자연스러운지 확인 부탁드립니다
  - 주문 생성 시 가게 지역 → 유저 주소 지역 순서로 검증하는데, 순서나 예외 메시지가 적절한지 봐주시면 좋겠습니다

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)