### PR TITLE
Feat/151 admin order read api

### DIFF
--- a/src/main/java/com/project/baedalsodae/order/controller/AdminOrderController.java
+++ b/src/main/java/com/project/baedalsodae/order/controller/AdminOrderController.java
@@ -9,52 +9,53 @@ import com.project.baedalsodae.order.dto.response.OrderListResponse;
 import com.project.baedalsodae.order.dto.response.OrderStatusResponse;
 import com.project.baedalsodae.order.service.OrderService;
 import com.project.baedalsodae.user.entity.UserRole;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
-
 @RestController
 @RequestMapping("/admins")
 @RequiredArgsConstructor
 public class AdminOrderController {
 
-	private final OrderService orderService;
+    private final OrderService orderService;
 
-	@PreAuthorize("hasAuthority('ROLE_MANAGER')")
-	@GetMapping("/orders")
-	public ResponseEntity<ApiResponse<OrderListResponse>> getOrders(
-			@AuthenticationPrincipal UserDetailsImpl userDetails,
-			@ModelAttribute OrderListRequest request) {
-		UserRole userRole = userDetails.getUserRole();
-		OrderListResponse response
-				= orderService.getOrders(userDetails.getUserId(), userRole.getRole(), request);
+    @PreAuthorize("hasAuthority('ROLE_MANAGER')")
+    @GetMapping("/orders")
+    public ResponseEntity<ApiResponse<OrderListResponse>> getOrders(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @ModelAttribute OrderListRequest request) {
+        UserRole userRole = userDetails.getUserRole();
+        OrderListResponse response =
+                orderService.getOrders(userDetails.getUserId(), userRole.getRole(), request);
 
-		return ResponseEntity.ok(ApiResponse.success(SuccessCode.ORDER_LIST, response));
-	}
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.ORDER_LIST, response));
+    }
 
-	@PreAuthorize("hasAuthority('ROLE_MANAGER')")
-	@GetMapping("/orders/{orderId}")
-	public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrderDetails(
-			@AuthenticationPrincipal UserDetailsImpl userDetails,
-			@PathVariable("orderId") UUID orderId) {
-		OrderDetailResponse response
-				= orderService.getOrderDetail(userDetails.getUserId(), userDetails.getUserRole(), null, orderId);
+    @PreAuthorize("hasAuthority('ROLE_MANAGER')")
+    @GetMapping("/orders/{orderId}")
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrderDetails(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("orderId") UUID orderId) {
+        OrderDetailResponse response =
+                orderService.getOrderDetail(
+                        userDetails.getUserId(), userDetails.getUserRole(), null, orderId);
 
-		return ResponseEntity.ok(ApiResponse.success(SuccessCode.ORDER_DETAIL, response));
-	}
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.ORDER_DETAIL, response));
+    }
 
-	@PreAuthorize("hasAuthority('ROLE_MANAGER')")
-	@GetMapping("/orders/{orderId}/status-history")
-	public ResponseEntity<ApiResponse<OrderStatusResponse>> getOrderStatusHistories(
-			@AuthenticationPrincipal UserDetailsImpl userDetails,
-			@PathVariable("orderId") UUID orderId) {
-		OrderStatusResponse response
-				= orderService.getOrderStatus(userDetails.getUserId(), userDetails.getUserRole(), null, orderId);
+    @PreAuthorize("hasAuthority('ROLE_MANAGER')")
+    @GetMapping("/orders/{orderId}/status-history")
+    public ResponseEntity<ApiResponse<OrderStatusResponse>> getOrderStatusHistories(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("orderId") UUID orderId) {
+        OrderStatusResponse response =
+                orderService.getOrderStatus(
+                        userDetails.getUserId(), userDetails.getUserRole(), null, orderId);
 
-		return ResponseEntity.ok(ApiResponse.success(SuccessCode.ORDER_STATUS, response));
-	}
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.ORDER_STATUS, response));
+    }
 }

--- a/src/main/java/com/project/baedalsodae/order/controller/AdminOrderController.java
+++ b/src/main/java/com/project/baedalsodae/order/controller/AdminOrderController.java
@@ -28,10 +28,10 @@ public class AdminOrderController {
 	@GetMapping("/orders")
 	public ResponseEntity<ApiResponse<OrderListResponse>> getOrders(
 			@AuthenticationPrincipal UserDetailsImpl userDetails,
-			@RequestParam(name = "roleCategory") UserRole role, 	// UserRole 상수명 반환(예: 요청 시 /admins/orders?roleCategory=CUSTOMER)
 			@ModelAttribute OrderListRequest request) {
+		UserRole userRole = userDetails.getUserRole();
 		OrderListResponse response
-				= orderService.getOrders(userDetails.getUserId(), role.getRole(), request);
+				= orderService.getOrders(userDetails.getUserId(), userRole.getRole(), request);
 
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.ORDER_LIST, response));
 	}

--- a/src/main/java/com/project/baedalsodae/order/controller/AdminOrderController.java
+++ b/src/main/java/com/project/baedalsodae/order/controller/AdminOrderController.java
@@ -1,0 +1,60 @@
+package com.project.baedalsodae.order.controller;
+
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
+import com.project.baedalsodae.global.common.ApiResponse;
+import com.project.baedalsodae.global.common.SuccessCode;
+import com.project.baedalsodae.order.dto.request.OrderListRequest;
+import com.project.baedalsodae.order.dto.response.OrderDetailResponse;
+import com.project.baedalsodae.order.dto.response.OrderListResponse;
+import com.project.baedalsodae.order.dto.response.OrderStatusResponse;
+import com.project.baedalsodae.order.service.OrderService;
+import com.project.baedalsodae.user.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/admins")
+@RequiredArgsConstructor
+public class AdminOrderController {
+
+	private final OrderService orderService;
+
+	@PreAuthorize("hasAuthority('ROLE_MANAGER')")
+	@GetMapping("/orders")
+	public ResponseEntity<ApiResponse<OrderListResponse>> getOrders(
+			@AuthenticationPrincipal UserDetailsImpl userDetails,
+			@RequestParam(name = "roleCategory") UserRole role, 	// UserRole 상수명 반환(예: 요청 시 /admins/orders?roleCategory=CUSTOMER)
+			@ModelAttribute OrderListRequest request) {
+		OrderListResponse response
+				= orderService.getOrders(userDetails.getUserId(), role.getRole(), request);
+
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.ORDER_LIST, response));
+	}
+
+	@PreAuthorize("hasAuthority('ROLE_MANAGER')")
+	@GetMapping("/orders/{orderId}")
+	public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrderDetails(
+			@AuthenticationPrincipal UserDetailsImpl userDetails,
+			@PathVariable("orderId") UUID orderId) {
+		OrderDetailResponse response
+				= orderService.getOrderDetail(userDetails.getUserId(), userDetails.getUserRole(), null, orderId);
+
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.ORDER_DETAIL, response));
+	}
+
+	@PreAuthorize("hasAuthority('ROLE_MANAGER')")
+	@GetMapping("/orders/{orderId}/status-history")
+	public ResponseEntity<ApiResponse<OrderStatusResponse>> getOrderStatusHistories(
+			@AuthenticationPrincipal UserDetailsImpl userDetails,
+			@PathVariable("orderId") UUID orderId) {
+		OrderStatusResponse response
+				= orderService.getOrderStatus(userDetails.getUserId(), userDetails.getUserRole(), null, orderId);
+
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.ORDER_STATUS, response));
+	}
+}

--- a/src/main/java/com/project/baedalsodae/order/dto/query/OrderListQuery.java
+++ b/src/main/java/com/project/baedalsodae/order/dto/query/OrderListQuery.java
@@ -58,4 +58,17 @@ public record OrderListQuery(
                 .cursorId(request.cursorId())
                 .build();
     }
+
+    public static OrderListQuery forAdmin(OrderListRequest request) {
+        return OrderListQuery.builder()
+                .status(request.status())
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .keyword(request.keyword())
+                .orderNo(request.orderNo())
+                .size(request.size())
+                .cursorCreatedAt(request.cursorCreatedAt())
+                .cursorId(request.cursorId())
+                .build();
+    }
 }

--- a/src/main/java/com/project/baedalsodae/order/repository/OrderQueryRepository.java
+++ b/src/main/java/com/project/baedalsodae/order/repository/OrderQueryRepository.java
@@ -9,4 +9,6 @@ public interface OrderQueryRepository {
     List<OrderSummaryResponse> findOrdersByCustomer(OrderListQuery query);
 
     List<OrderSummaryResponse> findOrdersByStore(OrderListQuery query);
+
+    List<OrderSummaryResponse> findAllOrders(OrderListQuery query);
 }

--- a/src/main/java/com/project/baedalsodae/order/repository/impl/OrderQueryRepositoryImpl.java
+++ b/src/main/java/com/project/baedalsodae/order/repository/impl/OrderQueryRepositoryImpl.java
@@ -71,4 +71,29 @@ public class OrderQueryRepositoryImpl implements OrderQueryRepository {
                 .limit(query.resolvedSize() + 1)
                 .fetch();
     }
+
+    @Override
+    public List<OrderSummaryResponse> findAllOrders(OrderListQuery query) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                OrderSummaryResponse.class,
+                                order.id,
+                                order.storeId,
+                                order.orderNo,
+                                order.status,
+                                order.storeNameSnapshot,
+                                order.finalAmount,
+                                order.createdAt))
+                .from(order)
+                .where(
+                        isDeletedIsFalse(),
+                        statusEq(query),
+                        dateRange(query),
+                        orderNoEqIgnoreCase(query),
+                        cursorCondition(query))
+                .orderBy(order.createdAt.desc(), order.id.desc())
+                .limit(query.resolvedSize() + 1)
+                .fetch();
+    }
 }

--- a/src/main/java/com/project/baedalsodae/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/project/baedalsodae/order/service/impl/OrderServiceImpl.java
@@ -120,6 +120,9 @@ public class OrderServiceImpl implements OrderService {
     public OrderListResponse getOrders(UUID userId, String role, OrderListRequest request) {
         validateDateRange(request.startDate(), request.endDate());
         // TODO 인증 도메인 완성 시 AOP로 권한 체크
+        if (UserRole.MANAGER.getRole().equals(role) || UserRole.MASTER.getRole().equals(role)) {
+            return getAdminOrders(request);
+        }
         if (UserRole.OWNER.getRole().equals(role)) {
             return getOwnerOrders(userId, request);
         }
@@ -147,6 +150,16 @@ public class OrderServiceImpl implements OrderService {
 
         OrderListQuery query = OrderListQuery.forOwner(store.getId(), request);
         List<OrderSummaryResponse> orders = orderQueryRepository.findOrdersByStore(query);
+
+        boolean hasNext = orders.size() > query.resolvedSize();
+        if (hasNext) orders = orders.subList(0, query.resolvedSize());
+
+        return OrderListResponse.from(orders, hasNext);
+    }
+
+    private OrderListResponse getAdminOrders(OrderListRequest request) {
+        OrderListQuery query = OrderListQuery.forAdmin(request);
+        List<OrderSummaryResponse> orders = orderQueryRepository.findAllOrders(query);
 
         boolean hasNext = orders.size() > query.resolvedSize();
         if (hasNext) orders = orders.subList(0, query.resolvedSize());

--- a/src/test/java/com/project/baedalsodae/order/controller/AdminOrderControllerTest.java
+++ b/src/test/java/com/project/baedalsodae/order/controller/AdminOrderControllerTest.java
@@ -1,0 +1,126 @@
+package com.project.baedalsodae.order.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.baedalsodae.auth.config.AuthConfig;
+import com.project.baedalsodae.auth.security.JwtProvider;
+import com.project.baedalsodae.auth.security.UserDetailsImpl;
+import com.project.baedalsodae.auth.security.util.TokenRedisUtil;
+import com.project.baedalsodae.global.common.SuccessCode;
+import com.project.baedalsodae.order.dto.request.OrderListRequest;
+import com.project.baedalsodae.order.dto.response.OrderDetailResponse;
+import com.project.baedalsodae.order.dto.response.OrderListResponse;
+import com.project.baedalsodae.order.dto.response.OrderStatusResponse;
+import com.project.baedalsodae.order.service.OrderService;
+import com.project.baedalsodae.user.entity.UserRole;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@WebMvcTest(AdminOrderController.class)
+@Import(AuthConfig.class)
+public class AdminOrderControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private OrderService orderService;
+
+    @MockitoBean private JwtProvider jwtProvider;
+
+    @MockitoBean private UserDetailsService userDetailsService;
+
+    @MockitoBean private TokenRedisUtil tokenRedisUtil;
+
+    private final String BASE_URL = "/admins/orders";
+
+    @Test
+    @DisplayName("성공 - 관리자 권한으로 전체 주문 목록 조회")
+    void getOrders_ByAdmin_Success() throws Exception {
+        // given
+        UUID adminId = UUID.randomUUID();
+        UserDetailsImpl admin = createUserDetails(adminId, UserRole.MANAGER);
+        OrderListResponse mockResponse = OrderListResponse.empty();
+
+        given(orderService.getOrders(eq(adminId), eq(UserRole.MANAGER.getRole()), any(OrderListRequest.class)))
+                .willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get(BASE_URL)
+                        .with(user(admin))
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(SuccessCode.ORDER_LIST.getCode()));
+    }
+
+    @Test
+    @DisplayName("성공 - 관리자 권한으로 단일 주문 상세 조회")
+    void getOrderDetail_ByAdmin_Success() throws Exception {
+        // given
+        UUID adminId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        UserDetailsImpl admin = createUserDetails(adminId, UserRole.MANAGER);
+        OrderDetailResponse mockResponse = OrderDetailResponse.builder().orderId(orderId).build();
+
+        given(orderService.getOrderDetail(eq(adminId), eq(UserRole.MANAGER), eq(null), eq(orderId)))
+                .willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get(BASE_URL + "/" + orderId)
+                        .with(user(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(SuccessCode.ORDER_DETAIL.getCode()));
+    }
+
+    @Test
+    @DisplayName("성공 - 관리자 권한으로 주문 상태 전이 이력 조회")
+    void getOrderStatusHistories_ByAdmin_Success() throws Exception {
+        // given
+        UUID adminId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        UserDetailsImpl admin = createUserDetails(adminId, UserRole.MANAGER);
+        OrderStatusResponse mockResponse = OrderStatusResponse.builder().orderId(orderId).build();
+
+        given(orderService.getOrderStatus(eq(adminId), eq(UserRole.MANAGER), eq(null), eq(orderId)))
+                .willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get(BASE_URL + "/" + orderId + "/status-history")
+                        .with(user(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(SuccessCode.ORDER_STATUS.getCode()));
+    }
+
+    @Test
+    @DisplayName("실패 - 일반 사용자 권한으로 관리자 주문 API 접근 시 거부(403)")
+    void getOrders_ByCustomer_Forbidden() throws Exception {
+        // given
+        UserDetailsImpl customer = createUserDetails(UUID.randomUUID(), UserRole.CUSTOMER);
+
+        // when & then
+        mockMvc.perform(get(BASE_URL)
+                        .with(user(customer))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    // Helper Method
+    private UserDetailsImpl createUserDetails(UUID userId, UserRole role) {
+        return UserDetailsImpl.from(userId, "adminUser", "password", role, false);
+    }
+}

--- a/src/test/java/com/project/baedalsodae/order/controller/AdminOrderControllerTest.java
+++ b/src/test/java/com/project/baedalsodae/order/controller/AdminOrderControllerTest.java
@@ -9,7 +9,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.baedalsodae.auth.config.AuthConfig;
 import com.project.baedalsodae.auth.security.JwtProvider;
 import com.project.baedalsodae.auth.security.UserDetailsImpl;
@@ -57,13 +56,15 @@ public class AdminOrderControllerTest {
         UserDetailsImpl admin = createUserDetails(adminId, UserRole.MANAGER);
         OrderListResponse mockResponse = OrderListResponse.empty();
 
-        given(orderService.getOrders(eq(adminId), eq(UserRole.MANAGER.getRole()), any(OrderListRequest.class)))
+        given(
+                        orderService.getOrders(
+                                eq(adminId),
+                                eq(UserRole.MANAGER.getRole()),
+                                any(OrderListRequest.class)))
                 .willReturn(mockResponse);
 
         // when & then
-        mockMvc.perform(get(BASE_URL)
-                        .with(user(admin))
-                        .param("size", "10"))
+        mockMvc.perform(get(BASE_URL).with(user(admin)).param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SuccessCode.ORDER_LIST.getCode()));
     }
@@ -81,8 +82,7 @@ public class AdminOrderControllerTest {
                 .willReturn(mockResponse);
 
         // when & then
-        mockMvc.perform(get(BASE_URL + "/" + orderId)
-                        .with(user(admin)))
+        mockMvc.perform(get(BASE_URL + "/" + orderId).with(user(admin)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SuccessCode.ORDER_DETAIL.getCode()));
     }
@@ -100,8 +100,7 @@ public class AdminOrderControllerTest {
                 .willReturn(mockResponse);
 
         // when & then
-        mockMvc.perform(get(BASE_URL + "/" + orderId + "/status-history")
-                        .with(user(admin)))
+        mockMvc.perform(get(BASE_URL + "/" + orderId + "/status-history").with(user(admin)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SuccessCode.ORDER_STATUS.getCode()));
     }
@@ -113,9 +112,7 @@ public class AdminOrderControllerTest {
         UserDetailsImpl customer = createUserDetails(UUID.randomUUID(), UserRole.CUSTOMER);
 
         // when & then
-        mockMvc.perform(get(BASE_URL)
-                        .with(user(customer))
-                        .with(csrf()))
+        mockMvc.perform(get(BASE_URL).with(user(customer)).with(csrf()))
                 .andExpect(status().isForbidden());
     }
 


### PR DESCRIPTION
### 📌 관련 이슈
- close #151 
- 
### 💡 작업 내용
- 관리자 전용 주문 컨트롤러 추가(AdminOrderController)
- 관리자 전용 주문 컨트롤러의 API별 권한 설정
- 관리자 전용 주문 조회 API 추가
  - 관리자 전용 전체 주문 검색/필터 조회(`/api/v1/admins/orders`)
  - 관리자 전용 단일 주문 상세 조회(`/api/v1/admins/orders/{orderId}`)
  - 관리자 주문 상태 전이 이력 조회(`/api/v1/admins/orders/{orderId}/status-history`)
- 단일 주문 상세 조회, 주문 상태 전이 이력 조회 기능에서는 기존 주문 서비스 로직을 재사용
- 전체 주문 검색/필터 조회의 경우, 관리자 전용 전체 주문 조회 쿼리 및 서비스 로직을 새로 추가
- AdminOrderController의 조회 기능 관련 컨트롤러 테스트코드 추가

### 🔍 변경 이유
- OrderServiceImpl 내부에 있는 기존의 getOrders()에서는 특정 사용자, 특정 가게에 관한 전체 주문 내역만 조회 가능했기 때문에, DB에 저장된 모든 주문 내역을 조회하기 위한 쿼리를 별도로 추가했습니다.

### 📝 리뷰 포인트 (선택)
- 기존 서비스 로직을 적절하게 재사용했는지

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)