### PR TITLE
fix: 회원가입 시 User 엔티티 createdBy 초기화 코드 추가 및 테스트코드 작성

### DIFF
--- a/src/main/java/com/project/baedalsodae/global/common/entity/BaseAuditEntity.java
+++ b/src/main/java/com/project/baedalsodae/global/common/entity/BaseAuditEntity.java
@@ -20,7 +20,7 @@ public class BaseAuditEntity extends BaseTimeEntity {
 
     @CreatedBy
     @Column(name = "created_by", updatable = false)
-    private UUID createdBy;
+    protected UUID createdBy;
 
     @LastModifiedBy
     @Column(name = "updated_by")

--- a/src/main/java/com/project/baedalsodae/user/entity/User.java
+++ b/src/main/java/com/project/baedalsodae/user/entity/User.java
@@ -58,7 +58,11 @@ public class User extends BaseAuditEntity {
     private List<UserAddress> userAddresses = new ArrayList<>();
 
     @PrePersist
-    public void prePersist() {}
+    public void prePersist() {
+        if (this.createdBy == null) {
+            this.createdBy = this.id;
+        }
+    }
 
     public static User create(
             String username,

--- a/src/test/java/com/project/baedalsodae/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/project/baedalsodae/user/repository/UserRepositoryTest.java
@@ -19,22 +19,21 @@ import org.springframework.test.util.ReflectionTestUtils;
 @Import(QueryDslConfig.class)
 public class UserRepositoryTest {
 
-    @Autowired
-    private UserRepository userRepository;
+    @Autowired private UserRepository userRepository;
 
     @Test
     @DisplayName("User 엔티티 저장 시 createdBy가 null이면 id 값으로 초기화되는지 확인")
     void user_Save_CheckCreatedByIsInitializedWithId() {
         // given
-        User user = User.create(
-                "testuser",
-                "010-1234-5678",
-                "test@test.com",
-                "encodedPassword",
-                "테스터",
-                "테스트닉네임",
-                UserRole.CUSTOMER
-        );
+        User user =
+                User.create(
+                        "testuser",
+                        "010-1234-5678",
+                        "test@test.com",
+                        "encodedPassword",
+                        "테스터",
+                        "테스트닉네임",
+                        UserRole.CUSTOMER);
 
         // when
         User savedUser = userRepository.saveAndFlush(user);
@@ -50,15 +49,15 @@ public class UserRepositoryTest {
     void user_Save_ByMaster_CheckCreatedByIsMasterId() {
         // given
         UUID masterId = UUID.randomUUID();
-        User manager = User.create(
-                "manager123",
-                "010-1111-2222",
-                "manager@test.com",
-                "encodedPassword",
-                "매니저",
-                "매니저닉네임",
-                UserRole.MANAGER
-        );
+        User manager =
+                User.create(
+                        "manager123",
+                        "010-1111-2222",
+                        "manager@test.com",
+                        "encodedPassword",
+                        "매니저",
+                        "매니저닉네임",
+                        UserRole.MANAGER);
         ReflectionTestUtils.setField(manager, "createdBy", masterId);
 
         // when

--- a/src/test/java/com/project/baedalsodae/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/project/baedalsodae/user/repository/UserRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.project.baedalsodae.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.project.baedalsodae.global.common.config.QueryDslConfig;
+import com.project.baedalsodae.user.entity.User;
+import com.project.baedalsodae.user.entity.UserRole;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import(QueryDslConfig.class)
+public class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("User 엔티티 저장 시 createdBy가 null이면 id 값으로 초기화되는지 확인")
+    void user_Save_CheckCreatedByIsInitializedWithId() {
+        // given
+        User user = User.create(
+                "testuser",
+                "010-1234-5678",
+                "test@test.com",
+                "encodedPassword",
+                "테스터",
+                "테스트닉네임",
+                UserRole.CUSTOMER
+        );
+
+        // when
+        User savedUser = userRepository.saveAndFlush(user);
+
+        // then
+        assertThat(savedUser.getId()).isNotNull();
+        assertThat(savedUser.getCreatedBy()).isNotNull();
+        assertThat(savedUser.getCreatedBy()).isEqualTo(savedUser.getId());
+    }
+
+    @Test
+    @DisplayName("MASTER 관리자가 MANAGER 계정 생성 시 createdBy가 MASTER의 ID로 유지되는지 확인")
+    void user_Save_ByMaster_CheckCreatedByIsMasterId() {
+        // given
+        UUID masterId = UUID.randomUUID();
+        User manager = User.create(
+                "manager123",
+                "010-1111-2222",
+                "manager@test.com",
+                "encodedPassword",
+                "매니저",
+                "매니저닉네임",
+                UserRole.MANAGER
+        );
+        ReflectionTestUtils.setField(manager, "createdBy", masterId);
+
+        // when
+        User savedManager = userRepository.saveAndFlush(manager);
+
+        // then
+        assertThat(savedManager.getId()).isNotNull();
+        assertThat(savedManager.getCreatedBy()).isEqualTo(masterId); // 본인 ID가 아닌 MASTER ID여야 함
+        assertThat(savedManager.getCreatedBy()).isNotEqualTo(savedManager.getId());
+    }
+}


### PR DESCRIPTION
### 📌 관련 이슈
- close #181 
- 
### 💡 작업 내용
- CUSTOMER, OWNER로 회원가입 시 createdBy 필드값 초기화 시점 문제로 인해 새로 생성된 user 엔티티의 UUID로 createdBy가 초기화되지 않고 null이 되는 문제 수정
- 관련 테스트코드 추가

### 🔍 변경 이유
- 

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)